### PR TITLE
Improved jetton verification

### DIFF
--- a/ton-http-api/src/core/tonlib_worker_tokens.cpp
+++ b/ton-http-api/src/core/tonlib_worker_tokens.cpp
@@ -219,6 +219,10 @@ td::Result<std::unique_ptr<TokenDataResult>> TonlibWorker::checkJettonWallet(
   TRY_RESULT(address_from_master_std, block::StdAddress::parse(wallet_address_from_master));
 
   LOG(DEBUG) << "address: " << address_std << " expected: " << address_from_master_std;
+  address_std.bounceable = true;
+  address_from_master_std.bounceable = true;
+  address_std.testnet = false;
+  address_from_master_std.testnet = false;
   if (address_from_master_std != address_std) {
     return td::Status::Error(409, "Verification on master failed");
   }


### PR DESCRIPTION
# Improved Jetton Verification
Before this update different forms of accounts (bounceable/non-bouncaeble, mainnet/testnet) were treated as different accounts. However, these addresses should be treated as equal.