### PR TITLE
add updated v2 schema

### DIFF
--- a/ton-http-api/schemas/v2.json
+++ b/ton-http-api/schemas/v2.json
@@ -1,0 +1,8250 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "TON HTTP API C++",
+    "description": "This API enables HTTP access to TON blockchain - getting accounts and wallets information, looking up blocks and transactions, sending messages to the blockchain, calling get methods of smart contracts, and more.\n\nIn addition to REST API, all methods are available through a JSON-RPC endpoint  with `method` equal to method name and `params` passed as a dictionary.\n\nThe response contains a JSON object, which always has a boolean field `ok` and either `error` or `result`. If `ok` equals true, the request was successful and the result of the query can be found in the `result` field. In case of an unsuccessful request, `ok` equals false and the error is explained in the `error`.\n\nAPI Key should be sent either as `api_key` query parameter or `X-API-Key` header\n",
+    "version": "2.1.1"
+  },
+  "servers": [
+    {
+      "url": "https://toncenter.com",
+      "description": "TON Mainnet"
+    },
+    {
+      "url": "https://testnet.toncenter.com",
+      "description": "TON Testnet"
+    }
+  ],
+  "paths": {
+    "/api/v2/getAddressInformation": {
+      "get": {
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Get address information",
+        "description": "Returns the current state of any account on the TON blockchain. Includes the balance (in nanotons), smart contract code and data (if deployed), account status, and a reference to the last transaction. This is the primary endpoint for checking if an address exists and what's deployed there.",
+        "operationId": "getAddressInformation_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          },
+          {
+            "$ref": "#/components/parameters/seqnoOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The complete current state of the requested account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressInformationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getExtendedAddressInformation": {
+      "get": {
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Get extended address information",
+        "description": "Returns detailed account information with parsed contract state. For wallet contracts, identifies the wallet version (v3, v4, v5) and extracts wallet-specific fields like `seqno` and public key. For other contracts, returns the raw state.",
+        "operationId": "getExtendedAddressInformation_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          },
+          {
+            "$ref": "#/components/parameters/seqnoOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns detailed account information including parsed contract state and type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedAddressInformationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getWalletInformation": {
+      "get": {
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Get wallet information",
+        "description": "Returns wallet-specific information for an address. If the address is a known wallet contract, returns the wallet type, current `seqno` (needed for sending transactions), and wallet_id. Always check `wallet: true` before using wallet-specific fields. Call this before sending any transaction to get the current `seqno`.",
+        "operationId": "getWalletInformation_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          },
+          {
+            "$ref": "#/components/parameters/seqnoOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns wallet-specific details: type, `seqno`, subwallet ID, and balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletInformationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getAddressBalance": {
+      "get": {
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Get address balance",
+        "description": "Returns the TON balance of an account in nanotons. 1 TON = 1,000,000,000 nanotons. A lightweight endpoint that returns only the balance without contract code, data, or other account details. Returns \"0\" for addresses that have never received any funds.",
+        "operationId": "getAddressBalance_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          },
+          {
+            "$ref": "#/components/parameters/seqnoOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the account balance in nanotons.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressBalanceResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getAddressState": {
+      "get": {
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Get address state",
+        "description": "Returns the lifecycle state of an account. Possible values: `uninitialized` (address has no deployed contract but can receive TON), `active` (contract is deployed and working), `frozen` (contract suspended due to zero balance, send TON to unfreeze). Refer to the [account lifecycle states documentation](/foundations/status) for details. Check this before interacting with a contract.",
+        "operationId": "getAddressState_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          },
+          {
+            "$ref": "#/components/parameters/seqnoOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the account lifecycle state: `uninit`, `active`, or `frozen`. Refer to the [account lifecycle states documentation](/foundations/status) for details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressStateResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getTokenData": {
+      "get": {
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Get token data",
+        "description": "Returns metadata for Jetton or NFT contracts. Automatically detects the contract type and returns appropriate fields. For Jetton masters: total supply, admin, metadata. For Jetton wallets: balance, owner. For NFT items: collection, owner, content. For NFT collections: item count, metadata.",
+        "operationId": "getTokenData_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns parsed token metadata for Jetton masters, Jetton wallets, NFT collections, and NFT items.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenDataResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "409": {
+            "$ref": "#/components/responses/409"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500_token"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getBlockTransactions": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Get block transactions",
+        "description": "Returns a summary of transactions in a specific block. Each item contains the account address and transaction ID, but not full transaction details. Use `count` to limit results and `after_lt`/`after_hash` for pagination. Call getTransactions with each transaction ID to get full details.",
+        "operationId": "getBlockTransactions_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/workchain"
+          },
+          {
+            "$ref": "#/components/parameters/shard"
+          },
+          {
+            "$ref": "#/components/parameters/seqno"
+          },
+          {
+            "$ref": "#/components/parameters/rootHashOptional"
+          },
+          {
+            "$ref": "#/components/parameters/fileHashOptional"
+          },
+          {
+            "$ref": "#/components/parameters/afterLtOptional"
+          },
+          {
+            "$ref": "#/components/parameters/afterAccountHashOptional"
+          },
+          {
+            "$ref": "#/components/parameters/countOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns short transaction identifiers (account, lt, hash) for transactions in the specified block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlockTransactionsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_block_tx"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getBlockTransactionsExt": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Get block transactions (extended)",
+        "description": "Returns full transaction objects for all transactions in a specific block. Each transaction includes complete data: inbound and outbound messages, fees, state changes, and BoC-encoded raw data. Use `count` to limit results and `after_lt`/`after_hash` for pagination when `incomplete` is true.",
+        "operationId": "getBlockTransactionsExt_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/workchain"
+          },
+          {
+            "$ref": "#/components/parameters/shard"
+          },
+          {
+            "$ref": "#/components/parameters/seqno"
+          },
+          {
+            "$ref": "#/components/parameters/rootHashOptional"
+          },
+          {
+            "$ref": "#/components/parameters/fileHashOptional"
+          },
+          {
+            "$ref": "#/components/parameters/afterLtOptional"
+          },
+          {
+            "$ref": "#/components/parameters/afterAccountHashOptional"
+          },
+          {
+            "$ref": "#/components/parameters/countOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns full transaction objects for transactions in the specified block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlockTransactionsExtResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_block_tx"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getTransactions": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Get transactions",
+        "description": "Returns transaction history for an account. Transactions are returned newest-first. Each transaction shows the incoming message that triggered it, all outgoing messages, and fees paid. For pagination: use the `lt` and `hash` from the oldest transaction as the starting point for the next request.",
+        "operationId": "getTransactions_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          },
+          {
+            "$ref": "#/components/parameters/limitOptional"
+          },
+          {
+            "$ref": "#/components/parameters/ltOptional"
+          },
+          {
+            "$ref": "#/components/parameters/hashOptional",
+            "description": "SHA-256 transaction hash to start pagination from"
+          },
+          {
+            "$ref": "#/components/parameters/toLtOptional"
+          },
+          {
+            "$ref": "#/components/parameters/archivalOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a list of transactions for the specified account, ordered by logical time.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_transaction"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getTransactionsStd": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Get transactions (standard)",
+        "description": "Returns transaction history for an account in a standardized format. Transactions are returned newest-first. Each transaction includes the triggering inbound message, all outbound messages, and fees paid. The response includes a `previous_transaction_id` cursor for paginating through older transactions.",
+        "operationId": "getTransactionsStd_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          },
+          {
+            "$ref": "#/components/parameters/limitOptional"
+          },
+          {
+            "$ref": "#/components/parameters/ltOptional"
+          },
+          {
+            "$ref": "#/components/parameters/hashOptional",
+            "description": "SHA-256 transaction hash to start pagination from"
+          },
+          {
+            "$ref": "#/components/parameters/toLtOptional"
+          },
+          {
+            "$ref": "#/components/parameters/archivalOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns transactions in standardized format with a pagination cursor.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TonlibResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_transaction"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/tryLocateTx": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Try locate transaction",
+        "description": "Finds a transaction by message parameters. Given a source address, destination address, and message creation time (created_lt), returns the transaction that processed this message. Useful for locating when a previously sent message was executed.",
+        "operationId": "tryLocateTx_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/sourceAddress"
+          },
+          {
+            "$ref": "#/components/parameters/destinationAddress"
+          },
+          {
+            "$ref": "#/components/parameters/createdLt"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the transaction matching the given source, destination, and created logical time.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocateTxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_locate"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/tryLocateResultTx": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Try locate result transaction",
+        "description": "Finds the transaction that received a specific message. Given message parameters, returns the transaction on the destination account that processed the incoming message. Use this to trace message delivery across accounts.",
+        "operationId": "tryLocateResultTx_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/sourceAddress"
+          },
+          {
+            "$ref": "#/components/parameters/destinationAddress"
+          },
+          {
+            "$ref": "#/components/parameters/createdLt"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the resulting transaction on the destination account for the given message.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocateResultTxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_locate"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/tryLocateSourceTx": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Try locate source transaction",
+        "description": "Finds the transaction that sent a specific message. Given message parameters, returns the transaction on the source account that created this outgoing message. Useful for tracing where a message originated from.",
+        "operationId": "tryLocateSourceTx_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/sourceAddress"
+          },
+          {
+            "$ref": "#/components/parameters/destinationAddress"
+          },
+          {
+            "$ref": "#/components/parameters/createdLt"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the originating transaction on the source account for the given message.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocateSourceTxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_locate"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getMasterchainInfo": {
+      "get": {
+        "tags": [
+          "Blocks"
+        ],
+        "summary": "Get masterchain info",
+        "description": "Returns the current state of the TON masterchain. The `last` field contains the latest block used for querying current state. The `seqno` in `last` is the current block height. Use this endpoint to obtain the latest block reference for other queries.",
+        "operationId": "getMasterchainInfo_get",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The current masterchain state, including the latest block identifier, its state root hash, and the genesis block reference. Use `result.last.seqno` as the current block height.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MasterchainInfoResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getMasterchainBlockSignatures": {
+      "get": {
+        "tags": [
+          "Blocks"
+        ],
+        "summary": "Get masterchain block signatures",
+        "description": "Returns validator signatures for a specific masterchain block. Each signature proves that a validator approved this block. Use this for building cryptographic proofs or verifying block authenticity in trustless applications.",
+        "operationId": "getMasterchainBlockSignatures_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/seqno"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns validator signatures for the specified masterchain block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MasterchainBlockSignaturesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_block"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getShardBlockProof": {
+      "get": {
+        "tags": [
+          "Blocks"
+        ],
+        "summary": "Get shard block proof",
+        "description": "Returns a Merkle proof that links a shardchain block to a masterchain block. This proof cryptographically verifies that the shard block is part of the canonical chain. Used by light clients and cross-chain bridges to verify shard data without trusting the API.",
+        "operationId": "getShardBlockProof_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/workchain"
+          },
+          {
+            "$ref": "#/components/parameters/shard"
+          },
+          {
+            "$ref": "#/components/parameters/seqno"
+          },
+          {
+            "name": "from_seqno",
+            "in": "query",
+            "description": "Seqno of masterchain block starting from which proof is required. If not specified latest masterchain block is used",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a cryptographic proof chain linking a shard block to the masterchain.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShardBlockProofResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_block"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getConsensusBlock": {
+      "get": {
+        "tags": [
+          "Blocks"
+        ],
+        "summary": "Get consensus block",
+        "description": "Returns the latest block that has reached consensus and is guaranteed to be final. This block will never be reverted, making it safe for confirming transactions that require absolute finality.",
+        "operationId": "getConsensusBlock_get",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The latest masterchain block that has achieved finality, guaranteed to never be reverted. Returns its sequence number and Unix timestamp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsensusBlockResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/lookupBlock": {
+      "get": {
+        "tags": [
+          "Blocks"
+        ],
+        "summary": "Lookup block",
+        "description": "Finds a block by position or time. Specify workchain and shard, then provide either: `seqno` (exact block number), lt (find block containing this logical time), or unixtime (find block closest to this timestamp). Returns the full block ID including hashes needed for verification.",
+        "operationId": "lookupBlock_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/workchain"
+          },
+          {
+            "$ref": "#/components/parameters/shard"
+          },
+          {
+            "$ref": "#/components/parameters/seqnoOptional"
+          },
+          {
+            "name": "lt",
+            "in": "query",
+            "description": "Logical time of a block",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-usrv-cpp-format": "std::int64_t"
+            }
+          },
+          {
+            "name": "unixtime",
+            "in": "query",
+            "description": "UNIX timestamp of a block",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the full block identifier matching the given `seqno`, logical time, or unix timestamp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LookupBlockResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_lookup"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getShards": {
+      "get": {
+        "tags": [
+          "Blocks"
+        ],
+        "summary": "Get shards",
+        "description": "Returns the active shardchain block identifiers at a given masterchain block height. Each shard processes a subset of accounts in parallel. The response shows how the basechain is currently partitioned and which block each shard is at.",
+        "operationId": "getShards_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/seqno",
+            "description": "Seqno of masterchain block"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the list of active shard block identifiers at the specified masterchain block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TonlibResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_block"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getBlockHeader": {
+      "get": {
+        "tags": [
+          "Blocks"
+        ],
+        "summary": "Get block header",
+        "description": "Returns block metadata without the full transaction list. Includes timestamps, validator info, and references to previous blocks. Intended for block explorers and other use cases that require block information without transactions.",
+        "operationId": "getBlockHeader_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/workchain"
+          },
+          {
+            "$ref": "#/components/parameters/shard"
+          },
+          {
+            "$ref": "#/components/parameters/seqno"
+          },
+          {
+            "$ref": "#/components/parameters/rootHashOptional"
+          },
+          {
+            "$ref": "#/components/parameters/fileHashOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the block header with merge/split flags, validator info, and timing data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlockHeaderResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_block"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getOutMsgQueueSize": {
+      "get": {
+        "tags": [
+          "Blocks"
+        ],
+        "summary": "Get outbound message queue size",
+        "description": "Returns the current size of the outbound message queue for each shard. A growing queue indicates network congestion. If the queue is large, transactions may take longer to process. Monitor this to detect network issues.",
+        "operationId": "getOutMsgQueueSize_get",
+        "responses": {
+          "200": {
+            "description": "Outgoing message queue sizes for all active shards. A growing queue indicates network congestion and may cause transaction delays.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutMsgQueueSizeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/runGetMethod": {
+      "post": {
+        "tags": [
+          "Run method"
+        ],
+        "summary": "Run get method",
+        "description": "Executes a read-only method on a smart contract. Get methods query contract state without sending a transaction. Common methods include `seqno` (wallet sequence number), `get_wallet_data` (wallet info), and `get_jetton_data` (token info). Method arguments are provided in the `stack` array.",
+        "operationId": "runGetMethod_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunGetMethodRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Returns the TVM stack output and exit code from executing the specified get method.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunGetMethodResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_run"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500_execution"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          },
+          "542": {
+            "$ref": "#/components/responses/542"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/runGetMethodStd": {
+      "post": {
+        "tags": [
+          "Run method"
+        ],
+        "summary": "Run get method (standard)",
+        "description": "Executes a read-only method on a smart contract using typed stack entries. Input and output stack entries use explicit types (`TvmStackEntryNumber`, `TvmStackEntryCell`, etc.) for structured input/output handling. Common methods: `seqno` (wallet sequence number), `get_wallet_data` (wallet info), `get_jetton_data` (token info).",
+        "operationId": "runGetMethodStd_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunGetMethodStdRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Returns the get method result in standardized stack format.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunGetMethodStdResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_run"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500_execution"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          },
+          "542": {
+            "$ref": "#/components/responses/542"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/sendBoc": {
+      "post": {
+        "tags": [
+          "Send"
+        ],
+        "summary": "Send BoC",
+        "description": "Broadcasts a signed message to the TON network. The `boc` parameter must contain a complete, signed external message in base64 format. The API validates the message and forwards it to validators. Returns immediately after acceptance; use getTransactions to confirm the transaction was processed.",
+        "operationId": "sendBoc_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendBocRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Returns a success confirmation after broadcasting the serialized message to the network.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendBocResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_send"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500_send"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/sendBocReturnHash": {
+      "post": {
+        "tags": [
+          "Send"
+        ],
+        "summary": "Send BoC (return hash)",
+        "description": "Broadcasts a signed message to the TON network and returns the message hash. The `boc` parameter must contain a complete, signed external message in base64 format. The API validates the message and forwards it to validators. The returned hash can be used to track the message's processing status.",
+        "operationId": "sendBocReturnHash_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendBocRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Returns the message hash after broadcasting the serialized message to the network.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendBocReturnHashResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_send"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500_send"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/estimateFee": {
+      "post": {
+        "tags": [
+          "Send"
+        ],
+        "summary": "Estimate fee",
+        "description": "Calculates the fees required to send a message. Provide the destination address and message body. For new contract deployments, also include init_code and init_data. Set ignore_chksig to true when estimating before signing. Returns a breakdown of storage, gas, and forwarding fees.",
+        "operationId": "estimateFee_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EstimateFeeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Returns the estimated fees (gas, storage, forwarding) for the specified message.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstimateFeeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_run"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500_execution"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/detectAddress": {
+      "get": {
+        "tags": [
+          "Utils"
+        ],
+        "summary": "Detect address",
+        "description": "Validates an address and returns it in all standard formats. Use this to convert between address formats or to validate user input. Returns raw format (0:abc), base64 bounceable (EQ), base64 non-bounceable (UQ), and URL-safe variants.",
+        "operationId": "detectAddress_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the address in all supported formats (raw, bounceable, non-bounceable) with base64 and URL-safe variants.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectAddressResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/detectHash": {
+      "get": {
+        "tags": [
+          "Utils"
+        ],
+        "summary": "Detect hash",
+        "description": "Validates a hash and returns it in all standard formats. Use this to convert between hex (64 chars) and base64 (44 chars) representations. Works with any 256-bit hash including transaction hashes, block hashes, and message hashes.",
+        "operationId": "detectHash_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/hash"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the hash in all supported formats (hex, base64, URL-safe base64).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectHashResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/packAddress": {
+      "get": {
+        "tags": [
+          "Utils"
+        ],
+        "summary": "Pack address",
+        "description": "Converts a raw address to user-friendly base64 format. Raw addresses use the format `workchain:hex` (e.g., `0:abc...`). The packed format is shorter and includes a checksum for error detection.",
+        "operationId": "packAddress_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the address converted to user-friendly (base64) format.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackAddressResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/unpackAddress": {
+      "get": {
+        "tags": [
+          "Utils"
+        ],
+        "summary": "Unpack address",
+        "description": "Converts a user-friendly base64 address back to its raw components. Returns the workchain ID, account hex, and flags indicating if the address is bounceable or testnet-only.",
+        "operationId": "unpackAddress_get",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/address"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the unpacked address components: workchain, hex account ID, and format flags.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnpackAddressResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_address"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getConfigParam": {
+      "get": {
+        "tags": [
+          "Configuration"
+        ],
+        "summary": "Get config parameter",
+        "description": "Returns a specific blockchain configuration parameter. TON stores all network settings on-chain as numbered parameters. Common ones: 0 (config contract), 1 (elector), 15 (election timing), 17 (stake limits), 20-21 (gas prices), 34 (current validators). Check TON documentation for the full list.",
+        "operationId": "getConfigParam_get",
+        "parameters": [
+          {
+            "name": "config_id",
+            "in": "query",
+            "description": "Parameter number",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "seqno",
+            "in": "query",
+            "description": "Block `seqno`",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the specified blockchain configuration parameter as a TVM cell.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigParamResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_config"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getConfigAll": {
+      "get": {
+        "tags": [
+          "Configuration"
+        ],
+        "summary": "Get all config parameters",
+        "description": "Returns all blockchain configuration parameters at once. Includes gas prices, validator settings, workchain configs, and governance rules. Use the optional `seqno` to get historical configuration at a specific block height.",
+        "operationId": "getConfigAll_get",
+        "parameters": [
+          {
+            "name": "seqno",
+            "in": "query",
+            "description": "Block `seqno`",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all blockchain configuration parameters as a single TVM cell.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigAllResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/getLibraries": {
+      "get": {
+        "tags": [
+          "Configuration"
+        ],
+        "summary": "Get libraries",
+        "description": "Returns smart contract library code by hash. Some contracts reference shared libraries instead of including all code directly. When a library reference appears in contract code, this endpoint fetches the actual library implementation.",
+        "operationId": "getLibraries_get",
+        "parameters": [
+          {
+            "name": "libraries",
+            "in": "query",
+            "description": "Hashes of libraries",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "#/components/schemas/TonHash"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the code of the requested shared library cells.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LibrariesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_libraries"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
+    "/api/v2/jsonRPC": {
+      "post": {
+        "tags": [
+          "RPC"
+        ],
+        "summary": "JSON-RPC endpoint",
+        "description": "All API methods are available through this single endpoint using JSON-RPC 2.0 protocol. Send the method name in the `method` field and parameters as a dictionary in `params`. Useful for calling multiple methods in sequence or when JSON-RPC is preferred over REST.",
+        "operationId": "jsonRPC_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Returns the result of the specified JSON-RPC method call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TonlibResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422_jsonrpc"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500_execution"
+          },
+          "504": {
+            "$ref": "#/components/responses/504"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Accounts",
+      "description": "Information about accounts"
+    },
+    {
+      "name": "Transactions",
+      "description": "Fetching and locating transactions"
+    },
+    {
+      "name": "Blocks",
+      "description": "Information about blocks"
+    },
+    {
+      "name": "Run method",
+      "description": "Run get-method of smart contracts"
+    },
+    {
+      "name": "Send",
+      "description": "Send data to blockchain"
+    },
+    {
+      "name": "Utils",
+      "description": "Some useful methods"
+    },
+    {
+      "name": "Configuration",
+      "description": "Information about blockchain config"
+    },
+    {
+      "name": "RPC",
+      "description": "JSON-RPC and POST endpoints"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "address": {
+        "name": "address",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/TonAddr"
+        },
+        "description": "The account address to query."
+      },
+      "hash": {
+        "name": "hash",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/TonHash"
+        }
+      },
+      "hashOptional": {
+        "name": "hash",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "$ref": "#/components/schemas/TonHash"
+        }
+      },
+      "workchain": {
+        "name": "workchain",
+        "in": "query",
+        "description": "The workchain to query. Use `-1` for masterchain (validators, system contracts, config) or `0` for basechain (regular accounts and contracts). Most user transactions happen on workchain `0`.",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "shard": {
+        "name": "shard",
+        "in": "query",
+        "description": "The shard identifier. Masterchain always uses `-9223372036854775808`. For basechain, shards split and merge dynamically. Use the `shards` endpoint to discover current shard configuration.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "x-usrv-cpp-type": "std::int64_t"
+        }
+      },
+      "seqno": {
+        "name": "seqno",
+        "in": "query",
+        "description": "Masterchain block sequence number (block height). Used to query state at a specific point in time. If omitted, returns the current state.",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "seqnoOptional": {
+        "name": "seqno",
+        "in": "query",
+        "description": "Query state at a specific block height. If omitted, returns the current state. Use this to look up historical data at a specific point in time.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "rootHashOptional": {
+        "name": "root_hash",
+        "in": "query",
+        "description": "The block's root hash for verification. Together with `file_hash`, this uniquely and cryptographically identifies a block. Only needed when proof of block identity is required.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "x-usrv-cpp-type": "#/components/schemas/TonHash"
+        }
+      },
+      "fileHashOptional": {
+        "name": "file_hash",
+        "in": "query",
+        "description": "The block's file hash for verification. Together with `root_hash`, this provides cryptographic proof of block identity. Only needed for trustless verification.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "x-usrv-cpp-type": "#/components/schemas/TonHash"
+        }
+      },
+      "afterLtOptional": {
+        "name": "after_lt",
+        "in": "query",
+        "description": "Pagination cursor. Pass the `lt` value from the last item in the previous response to get the next page. Transactions and messages are ordered by logical time.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "x-usrv-cpp-format": "std::int64_t"
+        }
+      },
+      "afterAccountHashOptional": {
+        "name": "after_hash",
+        "in": "query",
+        "description": "Secondary pagination cursor for block transactions. When multiple accounts have transactions at the same `lt`, use this to continue from a specific account.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "x-usrv-cpp-type": "#/components/schemas/TonAddrWithoutWorkchain"
+        }
+      },
+      "countOptional": {
+        "name": "count",
+        "in": "query",
+        "description": "Maximum number of items to return. The default is 40. Use smaller values for faster responses or larger values to reduce the number of API calls.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "default": 40,
+          "minimum": 1,
+          "maximum": 10000
+        }
+      },
+      "limitOptional": {
+        "name": "limit",
+        "in": "query",
+        "description": "Maximum number of transactions to return. The default is 10. For accounts with many transactions, use pagination (lt + hash) to fetch more.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "default": 10
+        }
+      },
+      "ltOptional": {
+        "name": "lt",
+        "in": "query",
+        "description": "Starting point for transaction history. Pass the lt from `last_transaction_id` to start from the most recent, or from a specific transaction to continue pagination.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "x-usrv-cpp-type": "std::int64_t"
+        }
+      },
+      "toLtOptional": {
+        "name": "to_lt",
+        "in": "query",
+        "description": "Stop fetching when reaching this logical time. Use this to limit the time range of returned transactions. Set to 0 (default) to fetch all available history.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "x-usrv-cpp-type": "std::int64_t",
+          "default": 0
+        }
+      },
+      "archivalOptional": {
+        "name": "archival",
+        "in": "query",
+        "description": "Request data from archival nodes. Regular nodes keep at least the last 2 days of history. Set to true when querying old transactions or historical state. Archival requests may be slower.",
+        "required": false,
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "sourceAddress": {
+        "name": "source",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/TonAddr"
+        },
+        "description": "Source account address."
+      },
+      "destinationAddress": {
+        "name": "destination",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/TonAddr"
+        },
+        "description": "Destination account address."
+      },
+      "createdLt": {
+        "name": "created_lt",
+        "in": "query",
+        "description": "The logical time when the message was created. Available in the `created_lt` field of message objects.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "x-usrv-cpp-type": "std::int64_t"
+        }
+      }
+    },
+    "responses": {
+      "default": {
+        "description": "Error response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TonlibErrorResponse"
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "API key does not exist. Check for typos or generate a new key.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 401,
+                  "description": "HTTP status code `401`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "API key does not exist"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 401,
+              "error": "API key does not exist"
+            }
+          }
+        }
+      },
+      "403": {
+        "description": "API key is not allowed for this network (e.g. testnet key used on mainnet).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 403,
+                  "description": "HTTP status code `403`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "Network not allowed"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 403,
+              "error": "Network not allowed"
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "Requested data not found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 404,
+                  "description": "HTTP status code `404`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "transaction not found"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 404,
+              "error": "transaction not found"
+            }
+          }
+        }
+      },
+      "409": {
+        "description": "Resource exists but is the wrong type.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 409,
+                  "description": "HTTP status code `409`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "Smart contract is not Jetton or NFT"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 409,
+              "error": "Smart contract is not Jetton or NFT"
+            }
+          }
+        }
+      },
+      "422_address": {
+        "description": "Invalid address or `seqno` parameter.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "empty address",
+                    "failed to parse address",
+                    "failed to parse seqno",
+                    "seqno should be positive"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "empty address"
+            }
+          }
+        }
+      },
+      "422_transaction": {
+        "description": "Invalid transaction query parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "failed to parse address",
+                    "failed to parse hash",
+                    "failed to parse lt",
+                    "lt should be non-negative",
+                    "lt and hash should be used together",
+                    "limit should be positive",
+                    "limit should be less or equal 1000"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "failed to parse address"
+            }
+          }
+        }
+      },
+      "422_locate": {
+        "description": "Invalid locate transaction parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "empty source address",
+                    "empty destination address",
+                    "failed to parse created_lt",
+                    "created_lt should be non-negative"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "empty source address"
+            }
+          }
+        }
+      },
+      "422_block": {
+        "description": "Invalid block query parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "workchain required",
+                    "shard required",
+                    "seqno required",
+                    "failed to parse workchain",
+                    "failed to parse shard",
+                    "failed to parse root_hash",
+                    "failed to parse seqno",
+                    "seqno should be positive",
+                    "from_seqno should be non-negative"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "workchain required"
+            }
+          }
+        }
+      },
+      "422_lookup": {
+        "description": "Invalid block lookup parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "failed to parse workchain",
+                    "failed to parse shard",
+                    "exactly one of seqno, lt, unixtime should be specified",
+                    "lt should be non-negative",
+                    "unixtime should be non-negative"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "failed to parse workchain"
+            }
+          }
+        }
+      },
+      "422_block_tx": {
+        "description": "Invalid block transactions parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "failed to parse workchain",
+                    "failed to parse shard",
+                    "failed to parse seqno",
+                    "after_lt and after_hash should be used together",
+                    "after_lt should be non-negative",
+                    "count should be positive",
+                    "count should be less or equal 10000"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "failed to parse workchain"
+            }
+          }
+        }
+      },
+      "422_send": {
+        "description": "Invalid send parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "empty boc"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "empty boc"
+            }
+          }
+        }
+      },
+      "422_run": {
+        "description": "Invalid get method or stack parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "Stack should be array",
+                    "Invalid stack format: array expected",
+                    "Invalid stack entry format: array of exact 2 elements expected",
+                    "Expected string as first element in stack entry",
+                    "Wrong type of number in stack entry",
+                    "Invalid tvm.Cell, base64 string expected",
+                    "Invalid tvm.Slice, base64 string expected",
+                    "Empty tvm.Cell",
+                    "Empty tvm.Slice"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "Stack should be array"
+            }
+          }
+        }
+      },
+      "422_config": {
+        "description": "Invalid config parameter request.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "failed to parse config_id",
+                    "failed to parse param",
+                    "only one of config_id or param should be specified",
+                    "param should be non-negative"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "failed to parse config_id"
+            }
+          }
+        }
+      },
+      "422_libraries": {
+        "description": "Invalid libraries parameter.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "failed to parse libraries"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "failed to parse libraries"
+            }
+          }
+        }
+      },
+      "422_jsonrpc": {
+        "description": "Invalid JSON-RPC request.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 422,
+                  "description": "HTTP status code `422`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "params must contain an object"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 422,
+              "error": "params must contain an object"
+            }
+          }
+        }
+      },
+      "429": {
+        "description": "Rate limit exceeded. Back off and retry, or use an API key for higher limits.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 429,
+                  "description": "HTTP status code `429`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "Ratelimit exceeded"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 429,
+              "error": "Ratelimit exceeded"
+            }
+          }
+        }
+      },
+      "500_send": {
+        "description": "Transaction simulation failed.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 500,
+                  "description": "HTTP status code `500`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "Exit code <N> != 0"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 500,
+              "error": "Exit code <N> != 0"
+            }
+          }
+        }
+      },
+      "500_execution": {
+        "description": "Get method or simulation execution failed.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 500,
+                  "description": "HTTP status code `500`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "Exit code <N> != 0",
+                    "Stack size <N> < 5",
+                    "Failed to parse int: <value>",
+                    "stackEntryNumber expected",
+                    "stackEntryCell expected at <N> position",
+                    "stackEntryCell or stackEntrySlice expected",
+                    "addr_ext is not supported",
+                    "addr_var is not supported",
+                    "anycast is not supported"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 500,
+              "error": "Exit code <N> != 0"
+            }
+          }
+        }
+      },
+      "500_token": {
+        "description": "Failed to retrieve or parse token data.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 500,
+                  "description": "HTTP status code `500`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "Failed to unpack token data",
+                    "Invalid uri",
+                    "missing uri field in offchain data",
+                    "failed to serialize TokenData",
+                    "Exit code <N> != 0",
+                    "Stack size <N> < 5"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 500,
+              "error": "Failed to unpack token data"
+            }
+          }
+        }
+      },
+      "504": {
+        "description": "Timeout waiting for liteserver response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 504,
+                  "description": "HTTP status code `504`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "LITE_SERVER_NETWORK timeout"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 504,
+              "error": "LITE_SERVER_NETWORK timeout"
+            }
+          }
+        }
+      },
+      "542": {
+        "description": "Liteserver-specific error or unsupported stack type.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ok",
+                "code",
+                "error"
+              ],
+              "properties": {
+                "ok": {
+                  "type": "boolean",
+                  "const": false,
+                  "description": "Always `false` for error responses."
+                },
+                "code": {
+                  "type": "integer",
+                  "const": 542,
+                  "description": "HTTP status code `542`."
+                },
+                "error": {
+                  "type": "string",
+                  "enum": [
+                    "Unsupported stack entry type: <type>"
+                  ]
+                },
+                "@extra": {
+                  "type": "string",
+                  "description": "Extra data passed through from the request."
+                }
+              }
+            },
+            "example": {
+              "ok": false,
+              "code": 542,
+              "error": "Unsupported stack entry type: <type>"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "APIKeyHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "API key header of the form `X-API-Key: <token>`, where `<token>` is the API key. Requests without a key are limited to 1 RPS. Refer to the [authentication guide](/ecosystem/api/toncenter/v2-authentication) for details."
+      },
+      "APIKeyQuery": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "api_key",
+        "description": "API key query parameter of the form `?api_key=<token>`, where `<token>` is the API key. Equivalent to the header method. Refer to the [authentication guide](/ecosystem/api/toncenter/v2-authentication) for details."
+      }
+    },
+    "schemas": {
+      "EmptyRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [],
+        "properties": {},
+        "description": "Empty request body for endpoints that require no parameters."
+      },
+      "AddressRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/TonAddr"
+          }
+        },
+        "description": "Request containing a single address parameter."
+      },
+      "AddressWithSeqnoRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/TonAddr"
+          },
+          "seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Masterchain block sequence number. Query the account state as it was at this block height. If omitted, returns the current state."
+          }
+        }
+      },
+      "SeqnoRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "seqno"
+        ],
+        "properties": {
+          "seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Masterchain block sequence number (block height). Used to query blockchain config at a specific block. If omitted, the latest masterchain block is used."
+          }
+        }
+      },
+      "DetectAddressRequest": {
+        "$ref": "#/components/schemas/AddressRequest"
+      },
+      "DetectHashRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "hash"
+        ],
+        "properties": {
+          "hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash value to detect encoding formats for."
+          }
+        }
+      },
+      "PackAddressRequest": {
+        "$ref": "#/components/schemas/AddressRequest"
+      },
+      "UnpackAddressRequest": {
+        "$ref": "#/components/schemas/AddressRequest"
+      },
+      "AddressInformationRequest": {
+        "$ref": "#/components/schemas/AddressWithSeqnoRequest"
+      },
+      "ExtendedAddressInformationRequest": {
+        "$ref": "#/components/schemas/AddressWithSeqnoRequest"
+      },
+      "WalletInformationRequest": {
+        "$ref": "#/components/schemas/AddressWithSeqnoRequest"
+      },
+      "AddressBalanceRequest": {
+        "$ref": "#/components/schemas/AddressWithSeqnoRequest"
+      },
+      "AddressStateRequest": {
+        "$ref": "#/components/schemas/AddressWithSeqnoRequest"
+      },
+      "TokenDataRequest": {
+        "$ref": "#/components/schemas/AddressWithSeqnoRequest"
+      },
+      "MasterchainInfoRequest": {
+        "$ref": "#/components/schemas/EmptyRequest"
+      },
+      "MasterchainBlockSignaturesRequest": {
+        "$ref": "#/components/schemas/SeqnoRequest"
+      },
+      "ShardBlockProofRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "workchain",
+          "shard",
+          "seqno"
+        ],
+        "properties": {
+          "workchain": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Workchain ID: `-1` for masterchain, `0` for basechain. Most user transactions are on workchain `0`."
+          },
+          "shard": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Shard identifier. A signed 64-bit integer. Masterchain uses -9223372036854775808."
+          },
+          "seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Shardchain block sequence number. Identifies a specific block within the given workchain and shard. Use together with `workchain` and `shard` to uniquely identify a block."
+          },
+          "from_seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Starting masterchain block for proof generation."
+          }
+        }
+      },
+      "ConsensusBlockRequest": {
+        "$ref": "#/components/schemas/EmptyRequest"
+      },
+      "LookupBlockRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "workchain",
+          "shard"
+        ],
+        "properties": {
+          "workchain": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Workchain ID: `-1` for masterchain, `0` for basechain. Most user transactions are on workchain `0`."
+          },
+          "shard": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Shard identifier. A signed 64-bit integer. Masterchain uses -9223372036854775808."
+          },
+          "seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Block sequence number within the specified workchain and shard. Use together with `workchain` and `shard` to uniquely identify a block. If omitted, the latest block is used."
+          },
+          "lt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Logical time of this event. A globally unique counter that orders all blockchain events. Higher values are more recent."
+          },
+          "unixtime": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Unix timestamp to look up."
+          }
+        },
+        "description": "Request to find a block by workchain, shard, and either `seqno`, lt, or unixtime."
+      },
+      "ShardsRequest": {
+        "$ref": "#/components/schemas/SeqnoRequest"
+      },
+      "BlockHeaderRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "workchain",
+          "shard",
+          "seqno"
+        ],
+        "properties": {
+          "workchain": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Workchain ID: `-1` for masterchain, `0` for basechain. Most user transactions are on workchain `0`."
+          },
+          "shard": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Shard identifier. A signed 64-bit integer. Masterchain uses -9223372036854775808."
+          },
+          "seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Block sequence number within the specified workchain and shard. Use together with `workchain` and `shard` to uniquely identify a block. If omitted, the latest block is used."
+          },
+          "root_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Merkle root hash of the block state tree. Used for cryptographic verification."
+          },
+          "file_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the serialized block data. Together with `root_hash`, uniquely identifies a block."
+          }
+        }
+      },
+      "OutMsgQueueSizeRequest": {
+        "$ref": "#/components/schemas/EmptyRequest"
+      },
+      "BlockTransactionsRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "workchain",
+          "shard",
+          "seqno"
+        ],
+        "properties": {
+          "workchain": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Workchain ID: `-1` for masterchain, `0` for basechain. Most user transactions are on workchain `0`."
+          },
+          "shard": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Shard identifier. A signed 64-bit integer. Masterchain uses -9223372036854775808."
+          },
+          "seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Block sequence number within the specified workchain and shard. Use together with `workchain` and `shard` to uniquely identify a block. If omitted, the latest block is used."
+          },
+          "root_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Merkle root hash of the block state tree. Used for cryptographic verification."
+          },
+          "file_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the serialized block data. Together with `root_hash`, uniquely identifies a block."
+          },
+          "after_lt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Return items after this logical time (for pagination)."
+          },
+          "after_hash": {
+            "$ref": "#/components/schemas/TonAddrWithoutWorkchain",
+            "description": "Return items after this hash (for pagination within same `lt`)."
+          },
+          "count": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Maximum number of items to return."
+          }
+        },
+        "description": "Request to fetch transactions from a specific block with optional pagination."
+      },
+      "BlockTransactionsExtRequest": {
+        "$ref": "#/components/schemas/BlockTransactionsRequest"
+      },
+      "TransactionsRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/TonAddr"
+          },
+          "lt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Logical time of this event. A globally unique counter that orders all blockchain events. Higher values are more recent."
+          },
+          "hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the starting transaction for pagination. Use together with `lt` from a previous response's `transaction_id`."
+          },
+          "to_lt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Stop returning items at this logical time."
+          },
+          "archival": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "x-usrv-cpp-type": "bool",
+            "description": "Whether to use archival nodes for old data."
+          },
+          "limit": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Maximum number of items to return."
+          }
+        },
+        "description": "Request to fetch transaction history for an account with optional pagination and filtering parameters."
+      },
+      "TransactionsV2Request": {
+        "$ref": "#/components/schemas/TransactionsRequest"
+      },
+      "TryLocateTxRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source",
+          "destination",
+          "created_lt"
+        ],
+        "properties": {
+          "source": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Sender address. Empty string for external messages (sent from outside the blockchain)."
+          },
+          "destination": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Recipient address."
+          },
+          "created_lt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int64",
+                "x-usrv-cpp-type": "std::int64_t"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Logical time when this message was created. Use with source and destination to uniquely identify a message."
+          }
+        }
+      },
+      "TryLocateResultTxRequest": {
+        "$ref": "#/components/schemas/TryLocateTxRequest"
+      },
+      "TryLocateSourceTxRequest": {
+        "$ref": "#/components/schemas/TryLocateTxRequest"
+      },
+      "ConfigParamRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "config_id"
+        ],
+        "properties": {
+          "config_id": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Configuration parameter number. Each number controls different blockchain settings."
+          },
+          "seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Masterchain block sequence number (block height). Used to query blockchain config at a specific block. If omitted, the latest masterchain block is used."
+          }
+        }
+      },
+      "ConfigAllRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "seqno": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "x-usrv-cpp-type": "std::int32_t",
+            "description": "Masterchain block sequence number (block height). Used to query blockchain config at a specific block. If omitted, the latest masterchain block is used."
+          }
+        }
+      },
+      "LibrariesRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "libraries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TonHash"
+            },
+            "description": "Array of library cell hashes to retrieve. Each hash is a 256-bit value in hex (64 chars) or base64 (44 chars) format."
+          }
+        }
+      },
+      "SendBocRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "boc"
+        ],
+        "properties": {
+          "boc": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Serialized external message in BoC format, base64 encoded. Contains the signed transaction to broadcast."
+          }
+        },
+        "description": "Request to broadcast a signed message. The boc field contains the base64-encoded external message."
+      },
+      "EstimateFeeRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "address",
+          "body"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/TonAddr"
+          },
+          "body": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Message body in BoC format, base64 encoded."
+          },
+          "init_code": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Contract code for deployment messages, BoC format, base64 encoded. Omit for regular transfers."
+          },
+          "init_data": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Initial contract storage for deployment, BoC format, base64 encoded. Omit for regular transfers."
+          },
+          "ignore_chksig": {
+            "type": "boolean",
+            "default": true,
+            "description": "Set to `true` to skip signature verification during fee estimation; otherwise `false`. Useful when a real signature is not yet available."
+          }
+        },
+        "description": "Request to estimate transaction fees. Include the target address, message body, and optionally init code/data for contract deployment."
+      },
+      "JsonRpcRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "jsonrpc",
+          "id",
+          "method",
+          "params"
+        ],
+        "properties": {
+          "jsonrpc": {
+            "type": "string",
+            "default": "2.0",
+            "description": "JSON-RPC protocol version identifier."
+          },
+          "id": {
+            "type": "string",
+            "description": "Request identifier. Echoed back in the response for matching async calls."
+          },
+          "method": {
+            "type": "string",
+            "description": "API method name to invoke (e.g., `getMasterchainInfo`, `getAddressBalance`)."
+          },
+          "params": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Method parameters as a JSON object with key-value pairs."
+          }
+        },
+        "description": "A JSON-RPC 2.0 request. Set `method` to the API method name (e.g., \"getWalletInformation\") and `params` to a dictionary of parameters."
+      },
+      "TonAddr": {
+        "type": "string",
+        "x-usrv-cpp-type": "ton_http::types::ton_addr",
+        "description": "Account address in [raw](/foundations/addresses/formats#raw-format) format (e.g., `0:ca6e321c...`) or [user-friendly](/foundations/addresses/formats#user-friendly-format) format (e.g., `EQDKbjIcfM...`). All formats are automatically detected."
+      },
+      "TonAddrWithoutWorkchain": {
+        "type": "string",
+        "x-usrv-cpp-type": "ton_http::types::ton_addr_without_workchain",
+        "description": "The account ID portion of an address without the workchain prefix. This is the 256-bit identifier in hex or base64 format."
+      },
+      "TonHash": {
+        "type": "string",
+        "x-usrv-cpp-type": "ton_http::types::ton_hash",
+        "description": "A 256-bit hash value. Accepts either hex format (64 characters) or base64 format (44 characters). Used for block hashes, transaction hashes, and cryptographic proofs."
+      },
+      "TonHashHex": {
+        "type": "string",
+        "x-usrv-cpp-type": "ton_http::types::ton_hash_hex",
+        "description": "A 256-bit hash in hexadecimal format. Exactly 64 characters (0-9, a-f)."
+      },
+      "Int256": {
+        "type": "string",
+        "x-usrv-cpp-type": "ton_http::types::int256",
+        "description": "A large integer represented as a string to avoid precision loss. Used for balances and other values that may exceed JavaScript's safe integer limit."
+      },
+      "Bytes": {
+        "type": "string",
+        "x-usrv-cpp-type": "ton_http::types::bytes",
+        "description": "Binary data encoded as base64. Used for serialized cells (BoC format), message bodies, and smart contract code/data."
+      },
+      "AccountAddress": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "accountAddress"
+            ],
+            "default": "accountAddress",
+            "description": "TonLib type identifier for account address objects. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "account_address": {
+            "type": "string",
+            "x-usrv-cpp-type": "ton_http::types::ton_addr",
+            "description": "The account address in raw format (`workchain:hex`), e.g. `0:abc123...`. Use the [pack address](/ecosystem/api/toncenter/v2/utils/pack-address) endpoint to convert to user-friendly base64 format."
+          }
+        }
+      },
+      "TonBlockIdExt": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ton.blockIdExt"
+            ],
+            "default": "ton.blockIdExt",
+            "description": "TonLib type identifier for full block identifiers. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "workchain": {
+            "type": "integer",
+            "description": "Workchain ID: `-1` for masterchain, `0` for basechain."
+          },
+          "shard": {
+            "type": "string",
+            "x-usrv-cpp-type": "std::int64_t",
+            "description": "Shard identifier as a signed 64-bit integer string. Masterchain uses `-9223372036854775808`."
+          },
+          "seqno": {
+            "type": "integer",
+            "description": "Block sequence number within its workchain and shard. For the masterchain (workchain `-1`), this equals the global block height. For basechain shards (workchain `0`), this is the sequence number local to that specific shard, not a global height."
+          },
+          "root_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Merkle root hash of the block state tree."
+          },
+          "file_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the serialized block file. Together with `root_hash`, uniquely identifies a block."
+          }
+        },
+        "required": [
+          "@type",
+          "workchain",
+          "shard",
+          "seqno",
+          "root_hash",
+          "file_hash"
+        ],
+        "description": "A complete block identifier with cryptographic hashes. Contains `workchain`, `shard`, `seqno` (position) plus `root_hash` and `file_hash` (verification)."
+      },
+      "DetectAddressBase64Variant": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "User-friendly address in both standard base64 and URL-safe base64 encodings.",
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.utils.detectedAddressVariant"
+            ],
+            "default": "ext.utils.detectedAddressVariant",
+            "description": "TonLib type identifier for base64 address encoding variants. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "b64": {
+            "type": "string",
+            "description": "Address in standard base64 encoding (48 characters, uses `+` and `/`)."
+          },
+          "b64url": {
+            "type": "string",
+            "description": "Address in URL-safe base64 encoding (48 characters, uses `-` and `_` instead of `+` and `/`)."
+          }
+        },
+        "required": [
+          "@type",
+          "b64",
+          "b64url"
+        ]
+      },
+      "ExtraCurrencyBalance": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "extraCurrency"
+            ],
+            "default": "extraCurrency",
+            "description": "TonLib type identifier for extra currency balance entries. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32",
+            "description": "A 32-bit integer identifying the extra currency. Currency IDs are defined at the blockchain configuration level and stored in `ConfigParam 7` of the masterchain. Refer to the [extra currency minting documentation](https://docs.ton.org/v3/documentation/infra/minter-flow) for details."
+          },
+          "amount": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Currency balance amount as a decimal string."
+          }
+        },
+        "required": [
+          "@type",
+          "id",
+          "amount"
+        ]
+      },
+      "InternalTransactionId": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A reference to a specific transaction. The combination of `lt` (logical time) and `hash` uniquely identifies any transaction. Use these values for pagination and lookups.",
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "internal.transactionId"
+            ],
+            "default": "internal.transactionId",
+            "description": "TonLib type identifier for transaction ID references. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "lt": {
+            "type": "string",
+            "description": "Logical time of this transaction. A globally unique counter that orders all events on the blockchain.",
+            "x-usrv-cpp-type": "std::int64_t"
+          },
+          "hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "SHA-256 hash of this transaction, encoded in base64."
+          }
+        },
+        "required": [
+          "@type",
+          "lt",
+          "hash"
+        ]
+      },
+      "AccountStateRaw": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "raw.accountState"
+            ],
+            "default": "raw.accountState",
+            "description": "TonLib type identifier for raw (unrecognized) contract states. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "code": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Smart contract code in BoC format, base64 encoded. Empty if account is uninitialized."
+          },
+          "data": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Smart contract persistent storage in BoC format, base64 encoded."
+          },
+          "frozen_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the frozen state. Only present for frozen accounts."
+          }
+        },
+        "required": [
+          "@type",
+          "code",
+          "data",
+          "frozen_hash"
+        ],
+        "title": "Raw account state",
+        "description": "Unrecognized or non-wallet contract state. Identified by `@type: raw.accountState`. Returned when TonLib cannot parse the contract as a known type."
+      },
+      "AccountStateWalletV3": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "wallet.v3.accountState"
+            ],
+            "default": "wallet.v3.accountState",
+            "description": "TonLib type identifier for Wallet v3 contracts. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "wallet_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Subwallet ID for v3+ wallets. Allows creating multiple wallets from one key. The default value is `0x29a9a317` (698983191) on both mainnet and testnet, derived from the first 4 bytes of the TON mainnet initial state hash. Note: v5 wallets use a different scheme with network-specific values to prevent cross-network transaction replay. Refer to the [wallet interaction guide](/standard/wallets/interact) for full details."
+          },
+          "seqno": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Wallet contract sequence number. Used for replay protection: each outgoing transaction must include the current `seqno` and increments it by 1. Fetch the current value before sending a transaction."
+          }
+        },
+        "required": [
+          "@type",
+          "wallet_id",
+          "seqno"
+        ],
+        "title": "Wallet v3",
+        "description": "Standard wallet contract version 3. Identified by `@type: wallet.v3.accountState`. The most widely deployed wallet type prior to v4."
+      },
+      "AccountStateWalletV4": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "wallet.v4.accountState"
+            ],
+            "default": "wallet.v4.accountState",
+            "description": "TonLib type identifier for Wallet v4 contracts. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "wallet_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Subwallet ID for v3+ wallets. Allows creating multiple wallets from one key. The default value is `0x29a9a317` (698983191) on both mainnet and testnet, derived from the first 4 bytes of the TON mainnet initial state hash. Note: v5 wallets use a different scheme with network-specific values to prevent cross-network transaction replay. Refer to the [wallet interaction guide](/standard/wallets/interact) for full details."
+          },
+          "seqno": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Wallet contract sequence number. Used for replay protection: each outgoing transaction must include the current `seqno` and increments it by 1. Fetch the current value before sending a transaction."
+          }
+        },
+        "required": [
+          "@type",
+          "wallet_id",
+          "seqno"
+        ],
+        "title": "Wallet v4",
+        "description": "Standard wallet contract version 4. Identified by `@type: wallet.v4.accountState`. Adds plugin support over v3."
+      },
+      "AccountStateWalletHighloadV1": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "wallet.highload.v1.accountState"
+            ],
+            "default": "wallet.highload.v1.accountState",
+            "description": "TonLib type identifier for Highload Wallet v1 contracts. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "wallet_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Subwallet ID for v3+ wallets. Allows creating multiple wallets from one key. The default value is `0x29a9a317` (698983191) on both mainnet and testnet, derived from the first 4 bytes of the TON mainnet initial state hash. Note: v5 wallets use a different scheme with network-specific values to prevent cross-network transaction replay. Refer to the [wallet interaction guide](/standard/wallets/interact) for full details."
+          },
+          "seqno": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Wallet contract sequence number. Used for replay protection: each outgoing transaction must include the current `seqno` and increments it by 1. Fetch the current value before sending a transaction."
+          }
+        },
+        "required": [
+          "@type",
+          "wallet_id",
+          "seqno"
+        ],
+        "title": "Highload wallet v1",
+        "description": "High-throughput wallet contract version 1. Identified by `@type: wallet.highload.v1.accountState`. Designed for sending many transactions in a single block."
+      },
+      "AccountStateWalletHighloadV2": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "wallet.highload.v2.accountState"
+            ],
+            "default": "wallet.highload.v2.accountState",
+            "description": "TonLib type identifier for Highload Wallet v2 contracts. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "wallet_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Subwallet ID for v3+ wallets. Allows creating multiple wallets from one key. The default value is `0x29a9a317` (698983191) on both mainnet and testnet, derived from the first 4 bytes of the TON mainnet initial state hash. Note: v5 wallets use a different scheme with network-specific values to prevent cross-network transaction replay. Refer to the [wallet interaction guide](/standard/wallets/interact) for full details."
+          }
+        },
+        "required": [
+          "@type",
+          "wallet_id"
+        ],
+        "title": "Highload wallet v2",
+        "description": "High-throughput wallet contract version 2. Identified by `@type: wallet.highload.v2.accountState`. Improved version of highload v1 with better replay protection."
+      },
+      "AccountStateDns": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "dns.accountState"
+            ],
+            "default": "dns.accountState",
+            "description": "TonLib type identifier for DNS resolver contracts. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "wallet_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Subwallet ID for v3+ wallets. Allows creating multiple wallets from one key. The default value is `0x29a9a317` (698983191) on both mainnet and testnet, derived from the first 4 bytes of the TON mainnet initial state hash. Note: v5 wallets use a different scheme with network-specific values to prevent cross-network transaction replay. Refer to the [wallet interaction guide](/standard/wallets/interact) for full details."
+          }
+        },
+        "required": [
+          "@type",
+          "wallet_id"
+        ],
+        "title": "DNS contract",
+        "description": "TON DNS contract state. Identified by `@type: dns.accountState`. Used by contracts that resolve TON domain names."
+      },
+      "RWalletLimit": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "rwallet.limit"
+            ],
+            "default": "rwallet.limit",
+            "description": "TonLib type identifier for restricted wallet spending limit rules. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "seconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Duration of this spending limit window in seconds."
+          },
+          "value": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum spendable amount within this time period, in nanotons."
+          }
+        },
+        "required": [
+          "@type",
+          "seconds",
+          "value"
+        ]
+      },
+      "RWalletConfig": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "rwallet.config"
+            ],
+            "default": "rwallet.config",
+            "description": "TonLib type identifier for restricted wallet configuration. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "start_at": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix timestamp when the spending limits become active."
+          },
+          "limits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RWalletLimit"
+            },
+            "description": "Array of spending limit rules. Each entry defines a time window in seconds and the maximum spendable amount in nanotons within that window."
+          }
+        },
+        "required": [
+          "@type",
+          "start_at",
+          "limits"
+        ]
+      },
+      "AccountStateRWallet": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "rwallet.accountState"
+            ],
+            "default": "rwallet.accountState",
+            "description": "TonLib type identifier for restricted wallet contracts. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "wallet_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Subwallet ID for v3+ wallets. Allows creating multiple wallets from one key. The default value is `0x29a9a317` (698983191) on both mainnet and testnet, derived from the first 4 bytes of the TON mainnet initial state hash. Note: v5 wallets use a different scheme with network-specific values to prevent cross-network transaction replay. Refer to the [wallet interaction guide](/standard/wallets/interact) for full details."
+          },
+          "seqno": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Wallet contract sequence number. Used for replay protection: each outgoing transaction must include the current `seqno` and increments it by 1. Fetch the current value before sending a transaction."
+          },
+          "unlocked_balance": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Balance available for immediate withdrawal, in nanotons."
+          },
+          "config": {
+            "$ref": "#/components/schemas/RWalletConfig",
+            "description": "Spending limits and restrictions configuration."
+          }
+        },
+        "required": [
+          "@type",
+          "wallet_id",
+          "seqno",
+          "unlocked_balance",
+          "config"
+        ],
+        "title": "Restricted wallet",
+        "description": "Restricted wallet contract state. Identified by `@type: rwallet.accountState`. Used for wallets with vesting or transfer restrictions."
+      },
+      "PChanConfig": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "pchan.config"
+            ],
+            "default": "pchan.config",
+            "description": "TonLib type identifier for payment channel configuration. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "alice_public_key": {
+            "type": "string",
+            "description": "Alice's Ed25519 public key for signing channel operations."
+          },
+          "alice_address": {
+            "$ref": "#/components/schemas/AccountAddress",
+            "description": "Alice's on-chain wallet address."
+          },
+          "bob_public_key": {
+            "type": "string",
+            "description": "Bob's Ed25519 public key for signing channel operations."
+          },
+          "bob_address": {
+            "$ref": "#/components/schemas/AccountAddress",
+            "description": "Bob's on-chain wallet address."
+          },
+          "init_timeout": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum seconds allowed to complete channel initialization before it expires."
+          },
+          "close_timeout": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum seconds allowed to complete cooperative channel closure."
+          },
+          "channel_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unique numeric identifier for this payment channel."
+          }
+        },
+        "required": [
+          "@type",
+          "alice_public_key",
+          "alice_address",
+          "bob_public_key",
+          "bob_address",
+          "init_timeout",
+          "close_timeout",
+          "channel_id"
+        ]
+      },
+      "PChanStateInit": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "pchan.stateInit"
+            ],
+            "default": "pchan.stateInit",
+            "description": "TonLib type identifier for payment channels in the initialization phase. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "signed_A": {
+            "type": "boolean",
+            "description": "Returns `true` if Alice has signed the initialization; otherwise `false`."
+          },
+          "signed_B": {
+            "type": "boolean",
+            "description": "Returns `true` if Bob has signed the initialization; otherwise `false`."
+          },
+          "min_A": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Minimum deposit required from Alice, in nanotons."
+          },
+          "min_B": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Minimum deposit required from Bob, in nanotons."
+          },
+          "expire_at": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix timestamp when the initialization offer expires."
+          },
+          "A": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Alice's deposited amount in nanotons."
+          },
+          "B": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Bob's deposited amount in nanotons."
+          }
+        },
+        "required": [
+          "@type",
+          "signed_A",
+          "signed_B",
+          "min_A",
+          "min_B",
+          "expire_at",
+          "A",
+          "B"
+        ]
+      },
+      "PChanStateClose": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "pchan.stateClose"
+            ],
+            "default": "pchan.stateClose",
+            "description": "TonLib type identifier for payment channels in the closing phase. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "signed_A": {
+            "type": "boolean",
+            "description": "Returns `true` if Alice has signed the close proposal; otherwise `false`."
+          },
+          "signed_B": {
+            "type": "boolean",
+            "description": "Returns `true` if Bob has signed the close proposal; otherwise `false`."
+          },
+          "min_A": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Minimum guaranteed payout for Alice, in nanotons."
+          },
+          "min_B": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Minimum guaranteed payout for Bob, in nanotons."
+          },
+          "expire_at": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix timestamp when the close proposal expires."
+          },
+          "A": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Alice's final balance in nanotons."
+          },
+          "B": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Bob's final balance in nanotons."
+          }
+        },
+        "required": [
+          "@type",
+          "signed_A",
+          "signed_B",
+          "min_A",
+          "min_B",
+          "expire_at",
+          "A",
+          "B"
+        ]
+      },
+      "PChanStatePayout": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "pchan.statePayout"
+            ],
+            "default": "pchan.statePayout",
+            "description": "TonLib type identifier for payment channels in the payout phase. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "A": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Alice's payout amount in nanotons."
+          },
+          "B": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Bob's payout amount in nanotons."
+          }
+        },
+        "required": [
+          "@type",
+          "A",
+          "B"
+        ]
+      },
+      "PChanState": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PChanStateInit"
+          },
+          {
+            "$ref": "#/components/schemas/PChanStateClose"
+          },
+          {
+            "$ref": "#/components/schemas/PChanStatePayout"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "@type",
+          "mapping": {
+            "pchan.stateInit": "#/components/schemas/PChanStateInit",
+            "pchan.stateClose": "#/components/schemas/PChanStateClose",
+            "pchan.statePayout": "#/components/schemas/PChanStatePayout"
+          }
+        }
+      },
+      "AccountStatePChan": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "pchan.accountState"
+            ],
+            "default": "pchan.accountState",
+            "description": "TonLib type identifier for payment channel contracts. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "config": {
+            "$ref": "#/components/schemas/PChanConfig",
+            "description": "Payment channel configuration (parties, timeouts, keys)."
+          },
+          "state": {
+            "$ref": "#/components/schemas/PChanState",
+            "description": "Current payment channel state (init, close, or payout phase)."
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable payment channel description."
+          }
+        },
+        "required": [
+          "@type",
+          "config",
+          "state",
+          "description"
+        ],
+        "title": "Payment channel",
+        "description": "Payment channel contract state. Identified by `@type: pchan.accountState`. Used for off-chain payment channels between two parties."
+      },
+      "AccountStateUninited": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "uninited.accountState"
+            ],
+            "default": "uninited.accountState",
+            "description": "TonLib type identifier for uninitialized accounts. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "frozen_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the frozen state. Present if account was frozen before being uninitialized."
+          }
+        },
+        "required": [
+          "@type",
+          "frozen_hash"
+        ],
+        "title": "Uninitialized",
+        "description": "Account exists on-chain but has no deployed contract. Identified by `@type: uninited.accountState`. The address has received TON but no code has been deployed yet."
+      },
+      "AccountState": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AccountStateRaw"
+          },
+          {
+            "$ref": "#/components/schemas/AccountStateWalletV3"
+          },
+          {
+            "$ref": "#/components/schemas/AccountStateWalletV4"
+          },
+          {
+            "$ref": "#/components/schemas/AccountStateWalletHighloadV1"
+          },
+          {
+            "$ref": "#/components/schemas/AccountStateWalletHighloadV2"
+          },
+          {
+            "$ref": "#/components/schemas/AccountStateDns"
+          },
+          {
+            "$ref": "#/components/schemas/AccountStateRWallet"
+          },
+          {
+            "$ref": "#/components/schemas/AccountStatePChan"
+          },
+          {
+            "$ref": "#/components/schemas/AccountStateUninited"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "@type",
+          "mapping": {
+            "raw.accountState": "#/components/schemas/AccountStateRaw",
+            "wallet.v3.accountState": "#/components/schemas/AccountStateWalletV3",
+            "wallet.v4.accountState": "#/components/schemas/AccountStateWalletV4",
+            "wallet.highload.v1.accountState": "#/components/schemas/AccountStateWalletHighloadV1",
+            "wallet.highload.v2.accountState": "#/components/schemas/AccountStateWalletHighloadV2",
+            "dns.accountState": "#/components/schemas/AccountStateDns",
+            "rwallet.accountState": "#/components/schemas/AccountStateRWallet",
+            "pchan.accountState": "#/components/schemas/AccountStatePChan",
+            "uninited.accountState": "#/components/schemas/AccountStateUninited"
+          }
+        }
+      },
+      "TokenContentDict": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "DnsRecordStorageAddress": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "bag_id"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "dns_storage_address"
+            ],
+            "default": "dns_storage_address",
+            "description": "TonLib type identifier for TON Storage DNS records. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "bag_id": {
+            "$ref": "#/components/schemas/TonHashHex",
+            "description": "TON Storage bag identifier in hex, pointing to distributed file storage."
+          }
+        }
+      },
+      "DnsRecordAdnlAddress": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "adnl_addr"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "dns_adnl_address"
+            ],
+            "default": "dns_adnl_address",
+            "description": "TonLib type identifier for ADNL address DNS records. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "adnl_addr": {
+            "$ref": "#/components/schemas/TonHashHex",
+            "description": "ADNL (Abstract Datagram Network Layer) address in hex, used for TON Sites and services."
+          }
+        }
+      },
+      "SmcAddr": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "workchain_id",
+          "address"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "addr_std"
+            ],
+            "default": "addr_std",
+            "description": "TonLib type identifier for standard smart contract addresses. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "workchain_id": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Workchain ID (`0` for basechain, `-1` for masterchain)."
+          },
+          "address": {
+            "$ref": "#/components/schemas/TonHashHex",
+            "description": "Account identifier as a 64-character hex string."
+          }
+        }
+      },
+      "DnsRecordSmcAddress": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "smc_addr"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "dns_smc_address"
+            ],
+            "default": "dns_smc_address",
+            "description": "TonLib type identifier for smart contract address DNS records. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "smc_addr": {
+            "$ref": "#/components/schemas/SmcAddr",
+            "description": "Smart contract address associated with this DNS record."
+          }
+        }
+      },
+      "DnsRecordNextResolver": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "resolver"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "dns_next_resolver"
+            ],
+            "default": "dns_next_resolver",
+            "description": "TonLib type identifier for next-resolver DNS records. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "resolver": {
+            "$ref": "#/components/schemas/SmcAddr",
+            "description": "Smart contract address of the next DNS resolver in the chain."
+          }
+        }
+      },
+      "DnsRecord": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DnsRecordStorageAddress"
+          },
+          {
+            "$ref": "#/components/schemas/DnsRecordSmcAddress"
+          },
+          {
+            "$ref": "#/components/schemas/DnsRecordAdnlAddress"
+          },
+          {
+            "$ref": "#/components/schemas/DnsRecordNextResolver"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "@type",
+          "mapping": {
+            "dns_storage_address": "#/components/schemas/DnsRecordStorageAddress",
+            "dns_smc_address": "#/components/schemas/DnsRecordSmcAddress",
+            "dns_adnl_address": "#/components/schemas/DnsRecordAdnlAddress",
+            "dns_next_resolver": "#/components/schemas/DnsRecordNextResolver"
+          }
+        }
+      },
+      "DnsRecordSet": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "dns_next_resolver": {
+            "$ref": "#/components/schemas/DnsRecord",
+            "description": "Next resolver contract for subdomain lookups."
+          },
+          "wallet": {
+            "$ref": "#/components/schemas/DnsRecord",
+            "description": "Wallet address associated with this domain."
+          },
+          "site": {
+            "$ref": "#/components/schemas/DnsRecord",
+            "description": "Site hosting address (ADNL or TON Storage)."
+          },
+          "storage": {
+            "$ref": "#/components/schemas/DnsRecord",
+            "description": "TON Storage bag ID for files hosted under this domain."
+          }
+        }
+      },
+      "DnsContent": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "domain",
+          "data"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "description": "The resolved domain name."
+          },
+          "data": {
+            "$ref": "#/components/schemas/DnsRecordSet",
+            "description": "Parsed DNS records for this domain."
+          }
+        }
+      },
+      "TokenContent": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "data"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "onchain",
+              "offchain"
+            ],
+            "description": "Storage method for token (jetton) metadata content: `onchain` (stored in contract data) or `offchain` (external URI)."
+          },
+          "data": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/TokenContentDict"
+              }
+            ],
+            "description": "Token metadata key-value pairs (name, symbol, decimals, image, description)."
+          }
+        }
+      },
+      "JettonMasterData": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "address",
+          "contract_type",
+          "total_supply",
+          "mintable",
+          "jetton_content",
+          "jetton_wallet_code"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.tokens.jettonMasterData"
+            ],
+            "default": "ext.tokens.jettonMasterData",
+            "description": "TonLib type identifier for Jetton master contract data. Refer to the [token type reference](/ecosystem/api/toncenter/v2-tonlib-types#token-types-ton-center-extensions) for a full list."
+          },
+          "address": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Contract address of this Jetton master."
+          },
+          "contract_type": {
+            "type": "string",
+            "enum": [
+              "jetton_master"
+            ],
+            "default": "jetton_master",
+            "description": "Type of token contract: jetton_master, jetton_wallet, nft_collection, or nft_item."
+          },
+          "total_supply": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Total tokens in circulation, in the smallest unit. Divide by 10^decimals for human-readable amount."
+          },
+          "mintable": {
+            "type": "boolean",
+            "description": "Returns `true` if new tokens can still be minted; `false` means the supply is permanently capped."
+          },
+          "admin_address": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Admin address that can mint tokens or update metadata. Empty if admin rights were revoked."
+          },
+          "jetton_content": {
+            "$ref": "#/components/schemas/TokenContent",
+            "description": "Token metadata: name, symbol, decimals, description, and image URL."
+          },
+          "jetton_wallet_code": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Code used to deploy individual user wallets for this token. Used to verify wallet authenticity."
+          }
+        },
+        "description": "Jetton (fungible token) master contract data. Contains total supply, whether minting is allowed, admin address, and token metadata (name, symbol, decimals). This is the central contract that tracks the token."
+      },
+      "JettonWalletData": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "address",
+          "contract_type",
+          "balance",
+          "owner",
+          "jetton",
+          "jetton_wallet_code"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.tokens.jettonWalletData"
+            ],
+            "default": "ext.tokens.jettonWalletData",
+            "description": "TonLib type identifier for Jetton wallet contract data. Refer to the [token type reference](/ecosystem/api/toncenter/v2-tonlib-types#token-types-ton-center-extensions) for a full list."
+          },
+          "address": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Contract address of this Jetton wallet."
+          },
+          "contract_type": {
+            "type": "string",
+            "enum": [
+              "jetton_wallet"
+            ],
+            "default": "jetton_wallet",
+            "description": "Type of token contract: jetton_master, jetton_wallet, nft_collection, or nft_item."
+          },
+          "balance": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "The token balance in the Jetton's base units (smallest denomination). To get the human-readable amount, divide by 10^decimals, where `decimals` is a metadata field on the Jetton master contract (commonly 9, but varies per token). Refer to the [Jetton overview](/standard/tokens/jettons/overview) for how Jetton decimals are defined."
+          },
+          "owner": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Wallet owner's address (the user who holds these tokens)."
+          },
+          "jetton": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Address of the Jetton master contract this wallet belongs to."
+          },
+          "mintless_is_claimed": {
+            "type": "boolean",
+            "description": "Returns `true` if the mintless jetton allocation has been claimed; otherwise `false`."
+          },
+          "jetton_wallet_code": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Wallet contract code. Should match the master contract's wallet code to verify authenticity."
+          }
+        },
+        "description": "Jetton wallet contract data. Each user has a separate wallet contract for each token they hold. Contains the token balance, owner address, and reference to the master contract."
+      },
+      "NftCollectionData": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "address",
+          "contract_type",
+          "next_item_index",
+          "collection_content"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.tokens.nftCollectionData"
+            ],
+            "default": "ext.tokens.nftCollectionData",
+            "description": "TonLib type identifier for NFT collection contract data. Refer to the [token type reference](/ecosystem/api/toncenter/v2-tonlib-types#token-types-ton-center-extensions) for a full list."
+          },
+          "address": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Contract address of this NFT collection."
+          },
+          "contract_type": {
+            "type": "string",
+            "enum": [
+              "nft_collection"
+            ],
+            "default": "nft_collection",
+            "description": "Type of token contract: jetton_master, jetton_wallet, nft_collection, or nft_item."
+          },
+          "next_item_index": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Index that will be assigned to the next minted NFT. Also indicates total items if minted sequentially."
+          },
+          "owner_address": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Collection owner's address. Controls minting and metadata updates."
+          },
+          "collection_content": {
+            "$ref": "#/components/schemas/TokenContent",
+            "description": "Collection metadata: name, description, and cover image."
+          }
+        },
+        "description": "NFT collection contract data. Contains the number of items minted, collection owner, and collection metadata (name, description, image)."
+      },
+      "NftItemData": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "address",
+          "contract_type",
+          "init",
+          "index",
+          "content"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.tokens.nftItemData"
+            ],
+            "default": "ext.tokens.nftItemData",
+            "description": "TonLib type identifier for NFT item contract data. Refer to the [token type reference](/ecosystem/api/toncenter/v2-tonlib-types#token-types-ton-center-extensions) for a full list."
+          },
+          "address": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Contract address of this NFT item."
+          },
+          "contract_type": {
+            "type": "string",
+            "enum": [
+              "nft_item"
+            ],
+            "default": "nft_item",
+            "description": "Type of token contract: jetton_master, jetton_wallet, nft_collection, or nft_item."
+          },
+          "init": {
+            "type": "boolean",
+            "description": "Returns `true` if this NFT item has been initialized (deployed); otherwise `false`."
+          },
+          "index": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "This item's sequential index within its collection."
+          },
+          "collection_address": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Address of the NFT collection this item belongs to. Empty if standalone NFT."
+          },
+          "owner_address": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Current owner's address. Changes on each transfer."
+          },
+          "content": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TokenContent"
+              },
+              {
+                "$ref": "#/components/schemas/DnsContent"
+              }
+            ],
+            "description": "NFT item metadata and content (name, description, image URL)."
+          }
+        },
+        "description": "Individual NFT data. Contains the item index, collection reference, current owner, and item-specific content/metadata."
+      },
+      "TokenData": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/JettonMasterData"
+          },
+          {
+            "$ref": "#/components/schemas/JettonWalletData"
+          },
+          {
+            "$ref": "#/components/schemas/NftCollectionData"
+          },
+          {
+            "$ref": "#/components/schemas/NftItemData"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "@type",
+          "mapping": {
+            "ext.tokens.jettonMasterData": "#/components/schemas/JettonMasterData",
+            "ext.tokens.jettonWalletData": "#/components/schemas/JettonWalletData",
+            "ext.tokens.nftCollectionData": "#/components/schemas/NftCollectionData",
+            "ext.tokens.nftItemData": "#/components/schemas/NftItemData"
+          }
+        },
+        "description": "Token metadata returned by getTokenData. Can be a Jetton master, Jetton wallet, NFT collection, or NFT item depending on which contract was queried."
+      },
+      "AccountStateEnum": {
+        "type": "string",
+        "enum": [
+          "uninitialized",
+          "active",
+          "frozen"
+        ],
+        "description": "The lifecycle state of an account: `uninitialized` (no contract deployed), `active` (contract working normally), or `frozen` (suspended due to zero balance). Refer to the [account lifecycle states documentation](/foundations/status) for details."
+      },
+      "BlockSignature": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.signature"
+            ],
+            "default": "blocks.signature",
+            "description": "TonLib type identifier for validator signature objects. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "node_id_short": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Short public key hash of the validator node that produced this signature."
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Ed25519 signature of the block by this validator, base64 encoded."
+          }
+        },
+        "required": [
+          "@type",
+          "node_id_short",
+          "signature"
+        ]
+      },
+      "ShardBlockLink": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.shardBlockLink"
+            ],
+            "default": "blocks.shardBlockLink",
+            "description": "TonLib type identifier for shard-to-masterchain proof links. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "id": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Block identifier for this link in the proof chain."
+          },
+          "proof": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Merkle proof data for this shard block link."
+          }
+        },
+        "required": [
+          "@type",
+          "id",
+          "proof"
+        ]
+      },
+      "BlockLinkBack": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.blockLinkBack"
+            ],
+            "default": "blocks.blockLinkBack",
+            "description": "TonLib type identifier for backward block link proofs. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "to_key_block": {
+            "type": "boolean",
+            "description": "Returns `true` if the destination block is a key block; otherwise `false`."
+          },
+          "from": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Source block in the proof chain."
+          },
+          "to": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Destination block in the proof chain."
+          },
+          "dest_proof": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Cryptographic proof for the destination block."
+          },
+          "proof": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Merkle proof linking the two blocks."
+          },
+          "state_proof": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "State proof validating the block link."
+          }
+        },
+        "required": [
+          "@type",
+          "to_key_block",
+          "from",
+          "to",
+          "dest_proof",
+          "proof",
+          "state_proof"
+        ]
+      },
+      "OutMsgQueueSize": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.outMsgQueueSize"
+            ],
+            "default": "blocks.outMsgQueueSize",
+            "description": "TonLib type identifier for per-shard queue size entries. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "id": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Full block identifier for the shard."
+          },
+          "size": {
+            "type": "integer",
+            "description": "Number of outgoing messages waiting in this shard's queue."
+          }
+        },
+        "required": [
+          "@type",
+          "id",
+          "size"
+        ]
+      },
+      "LibraryEntry": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "smc.libraryEntry"
+            ],
+            "default": "smc.libraryEntry",
+            "description": "TonLib type identifier for shared library cell entries. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Library cell hash."
+          },
+          "data": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Library cell code in BoC format, base64 encoded."
+          }
+        },
+        "required": [
+          "@type",
+          "hash",
+          "data"
+        ]
+      },
+      "ShortTxId": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Compact transaction reference containing the account address, logical time, and hash. Used in block transaction listings for efficient enumeration.",
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.shortTxId"
+            ],
+            "default": "blocks.shortTxId",
+            "description": "TonLib type identifier for compact transaction references. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "mode": {
+            "type": "integer",
+            "description": "Bitmask indicating which optional fields are present."
+          },
+          "account": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Account address that executed this transaction."
+          },
+          "lt": {
+            "type": "string",
+            "description": "Logical time of this transaction. A globally unique counter that orders all events on the blockchain.",
+            "x-usrv-cpp-type": "std::int64_t"
+          },
+          "hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "SHA-256 hash of this transaction, encoded in base64."
+          }
+        },
+        "required": [
+          "@type",
+          "mode",
+          "account",
+          "lt",
+          "hash"
+        ]
+      },
+      "MsgDataRaw": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "msg.dataRaw"
+            ],
+            "default": "msg.dataRaw",
+            "description": "TonLib type identifier for raw (binary) message bodies. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "body": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Raw message body in BoC format, base64 encoded."
+          },
+          "init_state": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Contract init state (code + data) attached to this message, base64 encoded. Present only for deploy messages."
+          }
+        }
+      },
+      "MsgDataText": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "msg.dataText"
+            ],
+            "default": "msg.dataText",
+            "description": "TonLib type identifier for plain text comment message bodies. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "text": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "UTF-8 text comment, base64 encoded."
+          }
+        }
+      },
+      "MsgDataDecryptedText": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "msg.dataDecryptedText"
+            ],
+            "default": "msg.dataDecryptedText",
+            "description": "TonLib type identifier for decrypted text message bodies. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "text": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Decrypted UTF-8 text content, base64 encoded."
+          }
+        }
+      },
+      "MsgDataEncryptedText": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "msg.dataEncryptedText"
+            ],
+            "default": "msg.dataEncryptedText",
+            "description": "TonLib type identifier for encrypted text message bodies. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "text": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Encrypted message payload, base64 encoded."
+          }
+        }
+      },
+      "MsgData": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/MsgDataRaw"
+          },
+          {
+            "$ref": "#/components/schemas/MsgDataText"
+          },
+          {
+            "$ref": "#/components/schemas/MsgDataDecryptedText"
+          },
+          {
+            "$ref": "#/components/schemas/MsgDataEncryptedText"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "@type",
+          "mapping": {
+            "msg.dataRaw": "#/components/schemas/MsgDataRaw",
+            "msg.dataText": "#/components/schemas/MsgDataText",
+            "msg.dataDecryptedText": "#/components/schemas/MsgDataDecryptedText",
+            "msg.dataEncryptedText": "#/components/schemas/MsgDataEncryptedText"
+          }
+        }
+      },
+      "MessageStd": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "raw.message"
+            ],
+            "default": "raw.message",
+            "description": "TonLib type identifier for raw message objects. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "SHA-256 hash of this message, encoded in base64."
+          },
+          "source": {
+            "$ref": "#/components/schemas/AccountAddress",
+            "description": "Sender account address. Empty for external inbound messages."
+          },
+          "destination": {
+            "$ref": "#/components/schemas/AccountAddress",
+            "description": "Recipient account address."
+          },
+          "value": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "TON amount transferred with this message, in nanotons."
+          },
+          "extra_currencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtraCurrencyBalance"
+            },
+            "description": "Array of extra currencies (native blockchain-level tokens, distinct from Jettons) transferred in this message. Each entry contains a currency ID (integer) and amount (decimal string). Empty array if no extra currencies were transferred."
+          },
+          "fwd_fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Forwarding fee deducted from the message value, in nanotons."
+          },
+          "ihr_fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Instant Hypercube Routing (IHR) fee in nanotons. Always `0`. This is hardcoded at the protocol level and cannot be changed."
+          },
+          "created_lt": {
+            "type": "string",
+            "description": "Logical time when this message was created.",
+            "x-usrv-cpp-type": "std::int64_t"
+          },
+          "body_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the message body."
+          },
+          "msg_data": {
+            "$ref": "#/components/schemas/MsgData",
+            "description": "Message body payload (raw, text comment, or encrypted)."
+          }
+        },
+        "required": [
+          "@type",
+          "hash",
+          "source",
+          "destination",
+          "value",
+          "extra_currencies",
+          "fwd_fee",
+          "ihr_fee",
+          "created_lt",
+          "body_hash",
+          "msg_data"
+        ]
+      },
+      "TransactionStd": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "raw.transaction"
+            ],
+            "default": "raw.transaction",
+            "description": "TonLib type identifier for raw transaction objects. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "address": {
+            "$ref": "#/components/schemas/AccountAddress",
+            "description": "Account address object for this transaction."
+          },
+          "utime": {
+            "type": "integer",
+            "description": "Unix timestamp when this transaction was executed."
+          },
+          "data": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Full transaction data serialized as BoC, base64 encoded."
+          },
+          "transaction_id": {
+            "$ref": "#/components/schemas/InternalTransactionId",
+            "description": "The transaction identifier, represented by logical time and transaction hash."
+          },
+          "fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Total fees paid for this transaction, in nanotons."
+          },
+          "storage_fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Storage fees in nanotons deducted from the account balance during the storage phase of this transaction. Covers the cost of storing the contract state on-chain since the last transaction."
+          },
+          "other_fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Fees in nanotons deducted from the account balance during the computation and action phases of this transaction. Covers the cost of TVM execution and processing outgoing messages."
+          },
+          "in_msg": {
+            "$ref": "#/components/schemas/MessageStd",
+            "description": "The inbound message that triggered this transaction."
+          },
+          "out_msgs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageStd"
+            },
+            "description": "Array of outbound messages produced by this transaction. Each message contains sender and recipient address objects, TON amount (nanotons as string), forwarding fee, and raw message body."
+          }
+        },
+        "required": [
+          "@type",
+          "address",
+          "utime",
+          "data",
+          "transaction_id",
+          "fee",
+          "storage_fee",
+          "other_fee",
+          "out_msgs"
+        ]
+      },
+      "TransactionExt": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TransactionStd"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "@type": {
+                "type": "string",
+                "enum": [
+                  "raw.transactionExt"
+                ],
+                "default": "raw.transactionExt",
+                "description": "Object type identifier. "
+              },
+              "account": {
+                "$ref": "#/components/schemas/TonAddr",
+                "description": "The account address that this transaction belongs to."
+              }
+            }
+          }
+        ]
+      },
+      "Message": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.message"
+            ],
+            "default": "ext.message",
+            "description": "TonLib type identifier for extended message objects with decoded comments. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "SHA-256 hash of this message, encoded in base64."
+          },
+          "source": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Sender address. Empty for external inbound messages."
+          },
+          "destination": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Recipient address."
+          },
+          "value": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "TON amount transferred with this message, in nanotons."
+          },
+          "extra_currencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtraCurrencyBalance"
+            },
+            "description": "Array of extra currencies (native blockchain-level tokens, distinct from Jettons) transferred in this message. Each entry contains a currency ID (integer) and amount (decimal string). Empty array if no extra currencies were transferred."
+          },
+          "fwd_fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Forwarding fee deducted from the message value, in nanotons."
+          },
+          "ihr_fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Instant Hypercube Routing (IHR) fee in nanotons. Always `0`. This is hardcoded at the protocol level and cannot be changed."
+          },
+          "created_lt": {
+            "type": "string",
+            "description": "Logical time when this message was created.",
+            "x-usrv-cpp-type": "std::int64_t"
+          },
+          "body_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the message body. Useful for verifying content without the full payload."
+          },
+          "msg_data": {
+            "$ref": "#/components/schemas/MsgData",
+            "description": "Message body payload (raw, text comment, or encrypted)."
+          },
+          "message": {
+            "type": "string",
+            "description": "Decoded UTF-8 text comment from the message body. Present only when the message body is a plain text comment (opcode `0x00000000`). Empty string otherwise."
+          },
+          "message_decode_error": {
+            "type": "string",
+            "description": "Error description if the message body could not be decoded as a text comment."
+          }
+        },
+        "required": [
+          "@type",
+          "hash",
+          "source",
+          "destination",
+          "value",
+          "extra_currencies",
+          "fwd_fee",
+          "ihr_fee",
+          "created_lt",
+          "body_hash",
+          "msg_data"
+        ],
+        "description": "A message between accounts. Contains sender, recipient, TON amount transferred, and the message body. The `created_lt` field orders messages globally."
+      },
+      "Transaction": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.transaction"
+            ],
+            "default": "ext.transaction",
+            "description": "TonLib type identifier for extended transaction objects with decoded messages. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "address": {
+            "$ref": "#/components/schemas/AccountAddress",
+            "description": "Account address object for this transaction."
+          },
+          "account": {
+            "$ref": "#/components/schemas/TonAddr",
+            "description": "Account address in raw format."
+          },
+          "utime": {
+            "type": "integer",
+            "description": "Unix timestamp when this transaction was executed."
+          },
+          "data": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Full transaction data serialized as BoC, base64 encoded."
+          },
+          "transaction_id": {
+            "$ref": "#/components/schemas/InternalTransactionId",
+            "description": "The transaction identifier, represented by logical time and transaction hash."
+          },
+          "fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Total fees paid for this transaction, in nanotons."
+          },
+          "storage_fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Storage fees in nanotons deducted from the account balance during the storage phase of this transaction. Covers the cost of storing the contract state on-chain since the last transaction."
+          },
+          "other_fee": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Fees in nanotons deducted from the account balance during the computation and action phases of this transaction. Covers the cost of TVM execution and processing outgoing messages."
+          },
+          "in_msg": {
+            "$ref": "#/components/schemas/Message",
+            "description": "The inbound message that triggered this transaction."
+          },
+          "out_msgs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            },
+            "description": "Array of outbound messages produced by this transaction. Each message contains sender, recipient, TON amount (nanotons as string), forwarding fee, message body, and optional decoded text comment."
+          }
+        },
+        "required": [
+          "@type",
+          "address",
+          "account",
+          "utime",
+          "data",
+          "transaction_id",
+          "fee",
+          "storage_fee",
+          "other_fee",
+          "out_msgs"
+        ]
+      },
+      "TonlibObject": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DetectAddress"
+          },
+          {
+            "$ref": "#/components/schemas/DetectHash"
+          },
+          {
+            "$ref": "#/components/schemas/AddressInformation"
+          },
+          {
+            "$ref": "#/components/schemas/ExtendedAddressInformation"
+          },
+          {
+            "$ref": "#/components/schemas/WalletInformation"
+          },
+          {
+            "$ref": "#/components/schemas/JettonMasterData"
+          },
+          {
+            "$ref": "#/components/schemas/JettonWalletData"
+          },
+          {
+            "$ref": "#/components/schemas/NftCollectionData"
+          },
+          {
+            "$ref": "#/components/schemas/NftItemData"
+          },
+          {
+            "$ref": "#/components/schemas/MasterchainInfo"
+          },
+          {
+            "$ref": "#/components/schemas/MasterchainBlockSignatures"
+          },
+          {
+            "$ref": "#/components/schemas/ShardBlockProof"
+          },
+          {
+            "$ref": "#/components/schemas/ConsensusBlock"
+          },
+          {
+            "$ref": "#/components/schemas/TonBlockIdExt"
+          },
+          {
+            "$ref": "#/components/schemas/Shards"
+          },
+          {
+            "$ref": "#/components/schemas/BlockHeader"
+          },
+          {
+            "$ref": "#/components/schemas/OutMsgQueueSizes"
+          },
+          {
+            "$ref": "#/components/schemas/BlockTransactions"
+          },
+          {
+            "$ref": "#/components/schemas/BlockTransactionsExt"
+          },
+          {
+            "$ref": "#/components/schemas/Transaction"
+          },
+          {
+            "$ref": "#/components/schemas/TransactionsStd"
+          },
+          {
+            "$ref": "#/components/schemas/ConfigInfo"
+          },
+          {
+            "$ref": "#/components/schemas/LibraryResult"
+          },
+          {
+            "$ref": "#/components/schemas/QueryFees"
+          },
+          {
+            "$ref": "#/components/schemas/ExtMessageInfo"
+          },
+          {
+            "$ref": "#/components/schemas/ResultOk"
+          },
+          {
+            "$ref": "#/components/schemas/RunGetMethodStdResult"
+          },
+          {
+            "$ref": "#/components/schemas/RunGetMethodResult"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "@type",
+          "mapping": {
+            "ext.utils.detectAddress": "#/components/schemas/DetectAddress",
+            "ext.utils.detectedHash": "#/components/schemas/DetectHash",
+            "raw.fullAccountState": "#/components/schemas/AddressInformation",
+            "fullAccountState": "#/components/schemas/ExtendedAddressInformation",
+            "ext.accounts.walletInformation": "#/components/schemas/WalletInformation",
+            "ext.tokens.jettonMasterData": "#/components/schemas/JettonMasterData",
+            "ext.tokens.jettonWalletData": "#/components/schemas/JettonWalletData",
+            "ext.tokens.nftCollectionData": "#/components/schemas/NftCollectionData",
+            "ext.tokens.nftItemData": "#/components/schemas/NftItemData",
+            "blocks.masterchainInfo": "#/components/schemas/MasterchainInfo",
+            "blocks.blockSignatures": "#/components/schemas/MasterchainBlockSignatures",
+            "blocks.shardBlockProof": "#/components/schemas/ShardBlockProof",
+            "ext.blocks.consensusBlock": "#/components/schemas/ConsensusBlock",
+            "ton.blockIdExt": "#/components/schemas/TonBlockIdExt",
+            "blocks.shards": "#/components/schemas/Shards",
+            "blocks.header": "#/components/schemas/BlockHeader",
+            "blocks.outMsgQueueSizes": "#/components/schemas/OutMsgQueueSizes",
+            "blocks.transactions": "#/components/schemas/BlockTransactions",
+            "blocks.transactionsExt": "#/components/schemas/BlockTransactionsExt",
+            "ext.transaction": "#/components/schemas/Transaction",
+            "raw.transactions": "#/components/schemas/TransactionsStd",
+            "configInfo": "#/components/schemas/ConfigInfo",
+            "query.fees": "#/components/schemas/QueryFees",
+            "smc.libraryResult": "#/components/schemas/LibraryResult",
+            "raw.extMessageInfo": "#/components/schemas/ExtMessageInfo",
+            "ok": "#/components/schemas/ResultOk",
+            "smc.runResult": "#/components/schemas/RunGetMethodStdResult",
+            "ext.runResult": "#/components/schemas/RunGetMethodResult"
+          }
+        }
+      },
+      "TonlibResponse": {
+        "type": "object",
+        "title": "TonlibResponse",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result",
+          "@extra"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "title": "Ok",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "type": "object",
+            "description": "The method return value. The structure depends on the method called; see individual method documentation for response schemas. Only present when `ok` is `true`.",
+            "additionalProperties": true
+          },
+          "@extra": {
+            "type": "string",
+            "title": "Extra information",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          },
+          "jsonrpc": {
+            "type": "string",
+            "description": "JSON-RPC protocol version identifier."
+          },
+          "id": {
+            "type": "string",
+            "description": "Echoed request identifier from the original JSON-RPC request."
+          }
+        }
+      },
+      "TonlibErrorResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The `ok` field is always false, `code` contains the HTTP status, and `error` describes what went wrong.",
+        "required": [
+          "ok",
+          "code",
+          "error"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": false,
+            "description": "Always `false` for error responses."
+          },
+          "code": {
+            "type": "integer",
+            "minimum": 400,
+            "maximum": 599,
+            "description": "HTTP status code. Common values: 404 (not found), 409 (conflict), 422 (validation error), 429 (rate limit), 500 (server error), 504 (timeout), 542 (liteserver error)."
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message explaining what went wrong."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Extra data passed through from the request."
+          }
+        }
+      },
+      "JsonRpcResponse": {
+        "allOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "jsonrpc",
+              "id"
+            ],
+            "properties": {
+              "jsonrpc": {
+                "type": "string",
+                "default": "2.0",
+                "description": "JSON-RPC protocol version identifier."
+              },
+              "id": {
+                "type": "string",
+                "description": "Request ID. Pass any string and it will be echoed in the response."
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/TonlibResponse"
+          }
+        ]
+      },
+      "JsonRpcErrorResponse": {
+        "allOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "jsonrpc",
+              "id"
+            ],
+            "properties": {
+              "jsonrpc": {
+                "type": "string",
+                "default": "2.0",
+                "description": "JSON-RPC protocol version identifier."
+              },
+              "id": {
+                "type": "string",
+                "description": "Request ID. Pass any string and it will be echoed in the response."
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/TonlibErrorResponse"
+          }
+        ]
+      },
+      "DetectAddress": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Detected address in all supported formats. Contains the raw on-chain form, bounceable and non-bounceable user-friendly representations (each in base64 and URL-safe base64), the format type of the original input, and the testnet-only flag from the user-friendly encoding.",
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.utils.detectedAddress"
+            ],
+            "default": "ext.utils.detectedAddress",
+            "description": "TonLib type identifier for address detection results. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "raw_form": {
+            "type": "string",
+            "description": "Raw address in `workchain_id:account_id` hex format (e.g., `0:abc...def`). This is the canonical on-chain representation without flags or checksum."
+          },
+          "bounceable": {
+            "$ref": "#/components/schemas/DetectAddressBase64Variant",
+            "description": "Bounceable form of the address in standard base64 and URL-safe base64. Bounceable addresses (prefix `E...`) instruct wallet software to set the bounce flag on outgoing messages, so funds are returned if the destination contract cannot process them."
+          },
+          "non_bounceable": {
+            "$ref": "#/components/schemas/DetectAddressBase64Variant",
+            "description": "Non-bounceable form of the address in standard base64 and URL-safe base64. Non-bounceable addresses (prefix `U...`) instruct wallet software to clear the bounce flag, ensuring funds are credited even if the recipient has no deployed contract."
+          },
+          "given_type": {
+            "type": "string",
+            "enum": [
+              "raw_form",
+              "friendly_bounceable",
+              "friendly_non_bounceable"
+            ],
+            "description": "The encoding format of the address as provided in the request (e.g., `raw_form`, `dns`, `friendly_bounceable`, `friendly_non_bounceable`)."
+          },
+          "test_only": {
+            "type": "boolean",
+            "description": "Returns `true` if the user-friendly address has the testnet-only flag set (`0x80`); otherwise `false`. This is a flag in the address encoding that tells wallet software to reject this address on mainnet. The underlying account itself can exist on both networks."
+          }
+        },
+        "required": [
+          "@type",
+          "raw_form",
+          "bounceable",
+          "non_bounceable",
+          "given_type",
+          "test_only"
+        ]
+      },
+      "DetectHash": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.utils.detectedHash"
+            ],
+            "default": "ext.utils.detectedHash",
+            "description": "TonLib type identifier for hash detection results. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "b64": {
+            "type": "string",
+            "title": "base64 form",
+            "description": "Hash in standard base64 encoding (44 characters, uses `+` and `/`)."
+          },
+          "b64url": {
+            "type": "string",
+            "title": "base64 url-safe form",
+            "description": "Hash in URL-safe base64 encoding (44 characters, uses `-` and `_` instead of `+` and `/`)."
+          },
+          "hex": {
+            "type": "string",
+            "title": "hex form",
+            "description": "Hash in lowercase hexadecimal encoding (64 characters)."
+          }
+        },
+        "required": [
+          "@type",
+          "b64",
+          "b64url",
+          "hex"
+        ],
+        "description": "Detected hash in all supported encoding formats: hex (64 characters), standard base64 (44 characters), and URL-safe base64."
+      },
+      "PackAddress": {
+        "type": "string",
+        "title": "Address packed in base64",
+        "x-usrv-cpp-type": "ton_http::types::bytes"
+      },
+      "UnpackAddress": {
+        "type": "string",
+        "title": "Address unpacked to raw form"
+      },
+      "AddressInformation": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "raw.fullAccountState"
+            ],
+            "default": "raw.fullAccountState",
+            "description": "TonLib type identifier for full account state responses. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "balance": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "The account balance in nanotons (the smallest unit of TON). 1 TON = 1,000,000,000 nanotons (10^9), so divide by 10^9 to get the human-readable TON amount. Refer to the [units and decimals guide](/ecosystem/wallet-apps/deep-links#read-more) for more context. If this field appears on a Jetton wallet, the balance is in the token's base units. Divide by 10^decimals, where `decimals` is defined by the Jetton master contract. Refer to the [Jetton overview](/standard/tokens/jettons/overview) for details on how Jetton decimals work."
+          },
+          "extra_currencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtraCurrencyBalance"
+            },
+            "description": "Array of non-TON currency balances held by this account. Each entry contains a currency ID (integer) and balance amount (decimal string). Empty array if the account holds no extra currencies."
+          },
+          "last_transaction_id": {
+            "$ref": "#/components/schemas/InternalTransactionId",
+            "description": "Reference to the most recent transaction. Use as starting point for getTransactions."
+          },
+          "block_id": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Full block identifier where this event occurred."
+          },
+          "code": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Smart contract code in BoC format, base64 encoded."
+          },
+          "data": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Raw transaction or contract data in BoC (Bag of Cells) format, base64 encoded."
+          },
+          "frozen_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "Hash of the frozen contract state. Only present for frozen accounts."
+          },
+          "sync_utime": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix timestamp of the block from which this data was read."
+          },
+          "state": {
+            "$ref": "#/components/schemas/AccountStateEnum",
+            "description": "Account state: uninit, active, or frozen."
+          },
+          "suspended": {
+            "type": "boolean",
+            "description": "Returns `true` if the account has been suspended by a governance decision; otherwise `false`."
+          }
+        },
+        "required": [
+          "@type",
+          "balance",
+          "extra_currencies",
+          "code",
+          "data",
+          "last_transaction_id",
+          "block_id",
+          "frozen_hash",
+          "sync_utime",
+          "state"
+        ],
+        "description": "Raw account state including balance, code, data, and status. The code and data fields contain the smart contract in BoC format."
+      },
+      "ExtendedAddressInformation": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "fullAccountState"
+            ],
+            "default": "fullAccountState",
+            "description": "TonLib type identifier for extended account state responses. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "address": {
+            "$ref": "#/components/schemas/AccountAddress",
+            "description": "Account address object."
+          },
+          "balance": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "The account balance in nanotons (the smallest unit of TON). 1 TON = 1,000,000,000 nanotons (10^9), so divide by 10^9 to get the human-readable TON amount. Refer to the [units and decimals guide](/ecosystem/wallet-apps/deep-links#read-more) for more context. If this field appears on a Jetton wallet, the balance is in the token's base units. Divide by 10^decimals, where `decimals` is defined by the Jetton master contract. Refer to the [Jetton overview](/standard/tokens/jettons/overview) for details on how Jetton decimals work."
+          },
+          "extra_currencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtraCurrencyBalance"
+            },
+            "description": "Array of non-TON currency balances held by this account. Each entry contains a currency ID (integer) and balance amount (decimal string). Empty array if the account holds no extra currencies."
+          },
+          "last_transaction_id": {
+            "$ref": "#/components/schemas/InternalTransactionId",
+            "description": "Reference to the most recent transaction. Use as starting point for getTransactions."
+          },
+          "block_id": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Full block identifier where this event occurred."
+          },
+          "sync_utime": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix timestamp of the block from which this data was read."
+          },
+          "account_state": {
+            "$ref": "#/components/schemas/AccountState",
+            "description": "Detailed account state including contract type and internal data."
+          },
+          "revision": {
+            "type": "integer",
+            "description": "Contract revision number. Different revisions may have different behavior."
+          }
+        },
+        "required": [
+          "@type",
+          "address",
+          "balance",
+          "extra_currencies",
+          "last_transaction_id",
+          "block_id",
+          "sync_utime",
+          "account_state",
+          "revision"
+        ]
+      },
+      "WalletInformation": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.accounts.walletInformation"
+            ],
+            "default": "ext.accounts.walletInformation",
+            "description": "TonLib type identifier for wallet info responses. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "wallet": {
+            "type": "boolean",
+            "description": "Returns `true` if this address is a recognized wallet contract type; otherwise `false`."
+          },
+          "balance": {
+            "type": "string",
+            "x-usrv-cpp-type": "ton_http::types::int256",
+            "description": "Account balance in nanotons as a decimal string."
+          },
+          "account_state": {
+            "$ref": "#/components/schemas/AccountStateEnum",
+            "description": "Account lifecycle state: `uninit`, `active`, or `frozen`."
+          },
+          "last_transaction_id": {
+            "$ref": "#/components/schemas/InternalTransactionId",
+            "description": "Reference to the most recent transaction. Use as starting point for getTransactions."
+          },
+          "wallet_type": {
+            "type": "string",
+            "enum": [
+              "wallet v1 r1",
+              "wallet v1 r2",
+              "wallet v1 r3",
+              "wallet v2 r1",
+              "wallet v2 r2",
+              "wallet v3 r1",
+              "wallet v3 r2",
+              "wallet v4 r1",
+              "wallet v4 r2",
+              "wallet v5 beta",
+              "wallet v5 r1"
+            ],
+            "description": "Wallet contract version (e.g., `wallet v4 r2`, `wallet v5 r1`). Empty if not a recognized wallet."
+          },
+          "seqno": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Wallet contract sequence number. Used for replay protection: each outgoing transaction must include the current `seqno` and increments it by 1. Fetch the current value before sending a transaction."
+          },
+          "wallet_id": {
+            "type": "integer",
+            "description": "Subwallet ID for v3+ wallets. Allows creating multiple wallets from one key. The default value is `0x29a9a317` (698983191) on both mainnet and testnet, derived from the first 4 bytes of the TON mainnet initial state hash. Note: v5 wallets use a different scheme with network-specific values to prevent cross-network transaction replay. Refer to the [wallet interaction guide](/standard/wallets/interact) for full details."
+          },
+          "is_signature_allowed": {
+            "type": "boolean",
+            "description": "Returns `true` if external signatures are enabled (v5 wallets only); `false` means the wallet is controlled only by plugins."
+          }
+        },
+        "required": [
+          "@type",
+          "wallet",
+          "balance",
+          "account_state",
+          "last_transaction_id"
+        ],
+        "description": "Information about a wallet account. The `wallet` field indicates if this is a known wallet type. If true, `wallet_type`, `seqno`, and `wallet_id` will be populated. Check `seqno` before sending transactions."
+      },
+      "AddressBalance": {
+        "$ref": "#/components/schemas/Int256"
+      },
+      "AddressState": {
+        "$ref": "#/components/schemas/AccountStateEnum"
+      },
+      "MasterchainInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.masterchainInfo"
+            ],
+            "default": "blocks.masterchainInfo",
+            "description": "TonLib type identifier for masterchain state info. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "last": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "The most recent masterchain block."
+          },
+          "state_root_hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "SHA-256 Merkle root hash of the entire blockchain state at the latest block."
+          },
+          "init": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "The genesis (first) masterchain block."
+          }
+        },
+        "required": [
+          "@type",
+          "last",
+          "state_root_hash",
+          "init"
+        ]
+      },
+      "MasterchainBlockSignatures": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.blockSignatures"
+            ],
+            "default": "blocks.blockSignatures",
+            "description": "TonLib type identifier for block signature collections. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "id": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Full block identifier for the signed block."
+          },
+          "signatures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlockSignature"
+            },
+            "description": "Array of validator signatures for this block. Each entry contains the validator's short node ID (base64 hash) and their Ed25519 signature (base64)."
+          }
+        },
+        "required": [
+          "@type",
+          "id",
+          "signatures"
+        ]
+      },
+      "ShardBlockProof": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.shardBlockProof"
+            ],
+            "default": "blocks.shardBlockProof",
+            "description": "TonLib type identifier for shard block proof chains. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "from": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "The shard block being proven."
+          },
+          "mc_id": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Masterchain block used as trust anchor for the proof."
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShardBlockLink"
+            },
+            "description": "Array of cryptographic links forming a proof chain from the shard block to the masterchain. Each link contains a block identifier and a Merkle proof (base64)."
+          },
+          "mc_proof": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlockLinkBack"
+            },
+            "description": "Array of masterchain block link proofs. Each entry contains source and destination block identifiers with corresponding Merkle proofs (base64) and state proofs (base64)."
+          }
+        },
+        "required": [
+          "@type",
+          "from",
+          "mc_id",
+          "links",
+          "mc_proof"
+        ]
+      },
+      "ConsensusBlock": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ext.blocks.consensusBlock"
+            ],
+            "default": "ext.blocks.consensusBlock",
+            "description": "TonLib type identifier for consensus block info. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "consensus_block": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Sequence number of the latest consensus block."
+          },
+          "timestamp": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Unix timestamp when the consensus block was created."
+          }
+        },
+        "required": [
+          "@type",
+          "consensus_block",
+          "timestamp"
+        ]
+      },
+      "LookupBlock": {
+        "$ref": "#/components/schemas/TonBlockIdExt"
+      },
+      "Shards": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.shards"
+            ],
+            "default": "blocks.shards",
+            "description": "TonLib type identifier for shard listing responses. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "shards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TonBlockIdExt"
+            },
+            "description": "Array of active shard block identifiers. Each entry contains `workchain` (integer), `shard` ID (string), `seqno` (integer), `root_hash` (base64/hex), and `file_hash` (base64/hex)."
+          }
+        },
+        "required": [
+          "@type",
+          "shards"
+        ],
+        "description": "List of shardchain blocks at a specific masterchain height. Shows how the basechain is currently partitioned."
+      },
+      "BlockHeader": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Block metadata including creation time, validator info, and links to previous blocks. Does not include the transactions themselves.",
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.header"
+            ],
+            "default": "blocks.header",
+            "description": "TonLib type identifier for block header objects. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "id": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Full block identifier including workchain, shard, `seqno`, and hashes."
+          },
+          "global_id": {
+            "type": "integer",
+            "description": "Global network ID (`-239` for mainnet, `-3` for testnet)."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Block format version number."
+          },
+          "after_merge": {
+            "type": "boolean",
+            "description": "Returns `true` if this block was created immediately after a shard merge; otherwise `false`."
+          },
+          "after_split": {
+            "type": "boolean",
+            "description": "Returns `true` if this block was created immediately after a shard split; otherwise `false`."
+          },
+          "before_split": {
+            "type": "boolean",
+            "description": "Returns `true` if this shard will split after this block; otherwise `false`."
+          },
+          "want_merge": {
+            "type": "boolean",
+            "description": "Returns `true` if validators have signaled a preference to merge this shard; otherwise `false`."
+          },
+          "want_split": {
+            "type": "boolean",
+            "description": "Returns `true` if validators have signaled a preference to split this shard; otherwise `false`."
+          },
+          "validator_list_hash_short": {
+            "type": "integer",
+            "description": "Short hash of the validator set active during this block."
+          },
+          "catchain_seqno": {
+            "type": "integer",
+            "description": "Catchain sequence number used for validator consensus."
+          },
+          "min_ref_mc_seqno": {
+            "type": "integer",
+            "description": "Minimum masterchain block `seqno` referenced by this block."
+          },
+          "is_key_block": {
+            "type": "boolean",
+            "description": "Returns `true` if this is a key block containing validator set changes or config updates; otherwise `false`."
+          },
+          "prev_key_block_seqno": {
+            "type": "integer",
+            "description": "Sequence number of the previous key block."
+          },
+          "start_lt": {
+            "type": "string",
+            "description": "Logical time at the start of this block.",
+            "x-usrv-cpp-type": "std::int64_t"
+          },
+          "end_lt": {
+            "type": "string",
+            "description": "Logical time at the end of this block. All transactions in this block have `lt` between `start_lt` and `end_lt`.",
+            "x-usrv-cpp-type": "std::int64_t"
+          },
+          "gen_utime": {
+            "type": "integer",
+            "description": "Unix timestamp when this block was generated."
+          },
+          "prev_blocks": {
+            "type": "array",
+            "description": "Array of previous block identifiers (`workchain`, `shard`, `seqno`, `root_hash`, `file_hash`). Usually contains one entry, but two after a shard merge.",
+            "items": {
+              "$ref": "#/components/schemas/TonBlockIdExt"
+            }
+          }
+        },
+        "required": [
+          "@type",
+          "id",
+          "global_id",
+          "version",
+          "after_merge",
+          "after_split",
+          "before_split",
+          "want_merge",
+          "want_split",
+          "validator_list_hash_short",
+          "catchain_seqno",
+          "min_ref_mc_seqno",
+          "is_key_block",
+          "prev_key_block_seqno",
+          "start_lt",
+          "end_lt",
+          "gen_utime",
+          "prev_blocks"
+        ]
+      },
+      "OutMsgQueueSizes": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.outMsgQueueSizes"
+            ],
+            "default": "blocks.outMsgQueueSizes",
+            "description": "TonLib type identifier for outgoing message queue size responses. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "shards": {
+            "type": "array",
+            "description": "Array of per-shard queue sizes. Each entry contains the shard's block identifier and the number of outgoing messages waiting in its queue (integer).",
+            "items": {
+              "$ref": "#/components/schemas/OutMsgQueueSize"
+            }
+          },
+          "ext_msg_queue_size_limit": {
+            "type": "integer",
+            "description": "Maximum allowed external message queue size before new messages are rejected."
+          }
+        },
+        "required": [
+          "@type",
+          "shards",
+          "ext_msg_queue_size_limit"
+        ]
+      },
+      "ConfigInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "configInfo"
+            ],
+            "default": "configInfo",
+            "description": "TonLib type identifier for blockchain configuration responses. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "config": {
+            "$ref": "#/components/schemas/TvmCell",
+            "description": "The requested configuration parameter value as a TVM cell."
+          }
+        },
+        "required": [
+          "@type",
+          "config"
+        ],
+        "description": "Blockchain configuration data. Contains one or more config parameters as requested. Each parameter controls different aspects of network operation."
+      },
+      "LibraryResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "smc.libraryResult"
+            ],
+            "default": "smc.libraryResult",
+            "description": "TonLib type identifier for library lookup results. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LibraryEntry"
+            },
+            "description": "Array of library entries. Each entry contains a hash (base64 or hex) identifying the library and a data field with the library code in BoC format (base64)."
+          }
+        },
+        "required": [
+          "@type",
+          "result"
+        ],
+        "description": "Library code fetched by hash. Contains the actual code cells for shared libraries referenced by smart contracts."
+      },
+      "BlockTransactions": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "List of short transaction identifiers found in a specific block, with a flag indicating whether more transactions are available for pagination.",
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.transactions"
+            ],
+            "default": "blocks.transactions",
+            "description": "TonLib type identifier for block transaction listings. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "id": {
+            "description": "Full block identifier for the queried block.",
+            "$ref": "#/components/schemas/TonBlockIdExt"
+          },
+          "req_count": {
+            "type": "integer",
+            "description": "The maximum number of transactions requested, as specified by the `count` request parameter. If `incomplete` is `true`, more transactions exist beyond this limit."
+          },
+          "incomplete": {
+            "type": "boolean",
+            "description": "Returns `true` if there are more transactions in this block; otherwise `false`. Use the last transaction as cursor for pagination."
+          },
+          "transactions": {
+            "type": "array",
+            "description": "Array of compact transaction references. Each entry contains the account address (string), logical time (string), and transaction hash (base64 or hex).",
+            "items": {
+              "$ref": "#/components/schemas/ShortTxId"
+            }
+          }
+        },
+        "required": [
+          "@type",
+          "id",
+          "req_count",
+          "incomplete",
+          "transactions"
+        ]
+      },
+      "BlockTransactionsExt": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "List of full transaction objects found in a specific block, with a flag indicating whether more transactions are available for pagination.",
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "blocks.transactionsExt"
+            ],
+            "default": "blocks.transactionsExt",
+            "description": "TonLib type identifier for extended block transaction listings. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "id": {
+            "description": "Full block identifier for the queried block.",
+            "$ref": "#/components/schemas/TonBlockIdExt"
+          },
+          "req_count": {
+            "type": "integer",
+            "description": "The maximum number of transactions requested, as specified by the `count` request parameter. If `incomplete` is `true`, more transactions exist beyond this limit."
+          },
+          "incomplete": {
+            "type": "boolean",
+            "description": "Returns `true` if there are more transactions in this block; otherwise `false`. Use the last transaction as cursor for pagination."
+          },
+          "transactions": {
+            "type": "array",
+            "description": "Array of full transaction objects. Each entry contains the account address, timestamps, inbound/outbound messages, fees (in nanotons), and the raw transaction BoC (base64).",
+            "items": {
+              "$ref": "#/components/schemas/TransactionExt"
+            }
+          }
+        },
+        "required": [
+          "@type",
+          "id",
+          "req_count",
+          "incomplete",
+          "transactions"
+        ]
+      },
+      "Transactions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Transaction"
+        }
+      },
+      "TransactionsStd": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "transactions",
+          "previous_transaction_id"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "raw.transactions"
+            ],
+            "default": "raw.transactions",
+            "description": "TonLib type identifier for paginated raw transaction lists. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "transactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransactionStd"
+            },
+            "description": "Array of transaction objects in standardized format. Each transaction contains address, timestamps, inbound/outbound messages, fees in nanotons, and raw BoC (base64)."
+          },
+          "previous_transaction_id": {
+            "$ref": "#/components/schemas/InternalTransactionId",
+            "description": "Use this as cursor to fetch the next page of older transactions."
+          }
+        }
+      },
+      "ExtMessageInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "hash",
+          "hash_norm"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "raw.extMessageInfo"
+            ],
+            "default": "raw.extMessageInfo",
+            "description": "TonLib type identifier for external message info after broadcast. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "hash": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "SHA-256 hash of the external message as accepted by the network."
+          },
+          "hash_norm": {
+            "$ref": "#/components/schemas/TonHash",
+            "description": "SHA-256 normalized message hash, stable across re-serializations. Defined in [TEP-467: normalized message hash](https://github.com/ton-blockchain/TEPs/blob/master/text/0467-normalized-message-hash.md)."
+          }
+        },
+        "description": "Information about a broadcast external message. Contains the message hash which can be used to track processing."
+      },
+      "ResultOk": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "ok"
+            ],
+            "default": "ok",
+            "description": "TonLib type identifier for successful operations with no return data. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          }
+        },
+        "description": "Simple success response with no additional data."
+      },
+      "SendBocResult": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ResultOk"
+          },
+          {
+            "$ref": "#/components/schemas/ExtMessageInfo"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "@type",
+          "mapping": {
+            "ok": "#/components/schemas/ResultOk",
+            "ext.messageInfo": "#/components/schemas/ExtMessageInfo"
+          }
+        }
+      },
+      "Fees": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "in_fwd_fee",
+          "storage_fee",
+          "gas_fee",
+          "fwd_fee"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "fees"
+            ],
+            "default": "fees",
+            "description": "TonLib type identifier for fee breakdown objects. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "in_fwd_fee": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Fee for importing this inbound message, in nanotons."
+          },
+          "storage_fee": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Storage fee charged for keeping the contract state on-chain, in nanotons."
+          },
+          "gas_fee": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Computation gas fee for executing contract code, in nanotons."
+          },
+          "fwd_fee": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Fee for forwarding outbound messages created by this transaction, in nanotons."
+          }
+        }
+      },
+      "QueryFees": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "source_fees",
+          "destination_fees"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "query.fees"
+            ],
+            "default": "query.fees",
+            "description": "TonLib type identifier for fee estimation results. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "source_fees": {
+            "$ref": "#/components/schemas/Fees",
+            "description": "Fees charged on the sending account."
+          },
+          "destination_fees": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Fees"
+            },
+            "description": "Array of fee breakdowns charged on the receiving account(s). One entry per destination in multi-hop transactions."
+          }
+        },
+        "description": "Estimated fees for a transaction. Shows the breakdown between storage fees (for contract state), gas fees (for computation), and forward fees (for message delivery)."
+      },
+      "TvmStackEntrySlice": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "slice"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.stackEntrySlice"
+            ],
+            "default": "tvm.stackEntrySlice",
+            "description": "TonLib type identifier for slice-typed stack entries. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "slice": {
+            "$ref": "#/components/schemas/TvmSlice",
+            "description": "The TVM slice value."
+          }
+        }
+      },
+      "TvmStackEntryCell": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "cell"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.stackEntryCell"
+            ],
+            "default": "tvm.stackEntryCell",
+            "description": "TonLib type identifier for cell-typed stack entries. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "cell": {
+            "$ref": "#/components/schemas/TvmCell",
+            "description": "The TVM cell value."
+          }
+        }
+      },
+      "TvmStackEntryNumber": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "number"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.stackEntryNumber"
+            ],
+            "default": "tvm.stackEntryNumber",
+            "description": "TonLib type identifier for number-typed stack entries. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "number": {
+            "$ref": "#/components/schemas/TvmNumberDecimal",
+            "description": "The TVM number value (arbitrary-precision decimal)."
+          }
+        }
+      },
+      "TvmStackEntryTuple": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "tuple"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.stackEntryTuple"
+            ],
+            "default": "tvm.stackEntryTuple",
+            "description": "TonLib type identifier for tuple-typed stack entries. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "tuple": {
+            "$ref": "#/components/schemas/TvmTuple",
+            "description": "The TVM tuple value."
+          }
+        }
+      },
+      "TvmStackEntryList": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "list"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.stackEntryList"
+            ],
+            "default": "tvm.stackEntryList",
+            "description": "TonLib type identifier for list-typed stack entries. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "list": {
+            "$ref": "#/components/schemas/TvmList",
+            "description": "The TVM list value."
+          }
+        }
+      },
+      "TvmStackEntryUnsupported": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.stackEntryUnsupported"
+            ],
+            "default": "tvm.stackEntryUnsupported",
+            "description": "TonLib type identifier for stack entries with unsupported types. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          }
+        }
+      },
+      "TvmSlice": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "bytes"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.slice"
+            ],
+            "default": "tvm.slice",
+            "description": "TonLib type identifier for TVM slice values. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "bytes": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "TVM slice data serialized as base64."
+          }
+        }
+      },
+      "TvmCell": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "bytes"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.cell"
+            ],
+            "default": "tvm.cell",
+            "description": "TonLib type identifier for TVM cell values. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "bytes": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "TVM cell data serialized as base64."
+          }
+        }
+      },
+      "TvmNumberDecimal": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "number"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.numberDecimal"
+            ],
+            "default": "tvm.numberDecimal",
+            "description": "TonLib type identifier for TVM decimal number values. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "number": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Integer value as a decimal string (supports arbitrarily large numbers)."
+          }
+        }
+      },
+      "TvmTuple": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "elements"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.tuple"
+            ],
+            "default": "tvm.tuple",
+            "description": "TonLib type identifier for TVM tuple structures. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "elements": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TvmStackEntrySlice",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryCell",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryNumber",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryTuple",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryList",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryUnsupported",
+                  "x-usrv-cpp-indirect": true
+                }
+              ],
+              "discriminator": {
+                "propertyName": "@type",
+                "mapping": {
+                  "tvm.stackEntrySlice": "#/components/schemas/TvmStackEntrySlice",
+                  "tvm.stackEntryCell": "#/components/schemas/TvmStackEntryCell",
+                  "tvm.stackEntryNumber": "#/components/schemas/TvmStackEntryNumber",
+                  "tvm.stackEntryTuple": "#/components/schemas/TvmStackEntryTuple",
+                  "tvm.stackEntryList": "#/components/schemas/TvmStackEntryList",
+                  "tvm.stackEntryUnsupported": "#/components/schemas/TvmStackEntryUnsupported"
+                }
+              }
+            },
+            "description": "Ordered tuple of TVM stack entries. Each element is a typed object with `@type` discriminator (`tvm.stackEntryNumber`, `tvm.stackEntryCell`, `tvm.stackEntrySlice`, `tvm.stackEntryTuple`, or `tvm.stackEntryList`)."
+          }
+        }
+      },
+      "TvmList": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "elements"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "tvm.list"
+            ],
+            "default": "tvm.list",
+            "description": "TonLib type identifier for TVM list structures. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "elements": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TvmStackEntrySlice",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryCell",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryNumber",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryTuple",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryList",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryUnsupported",
+                  "x-usrv-cpp-indirect": true
+                }
+              ],
+              "discriminator": {
+                "propertyName": "@type",
+                "mapping": {
+                  "tvm.stackEntrySlice": "#/components/schemas/TvmStackEntrySlice",
+                  "tvm.stackEntryCell": "#/components/schemas/TvmStackEntryCell",
+                  "tvm.stackEntryNumber": "#/components/schemas/TvmStackEntryNumber",
+                  "tvm.stackEntryTuple": "#/components/schemas/TvmStackEntryTuple",
+                  "tvm.stackEntryList": "#/components/schemas/TvmStackEntryList",
+                  "tvm.stackEntryUnsupported": "#/components/schemas/TvmStackEntryUnsupported"
+                }
+              }
+            },
+            "description": "Ordered list of TVM stack entries. Each element is a typed object with `@type` discriminator (`tvm.stackEntryNumber`, `tvm.stackEntryCell`, `tvm.stackEntrySlice`, `tvm.stackEntryTuple`, or `tvm.stackEntryList`)."
+          }
+        }
+      },
+      "RunGetMethodStdRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "address",
+          "method",
+          "stack"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/TonAddr"
+          },
+          "method": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "description": "The get method name (e.g., \"`seqno`\", \"get_wallet_data\") or its numeric ID."
+          },
+          "stack": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TvmStackEntrySlice",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryCell",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryNumber",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryTuple",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryList",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryUnsupported",
+                  "x-usrv-cpp-indirect": true
+                }
+              ],
+              "discriminator": {
+                "propertyName": "@type",
+                "mapping": {
+                  "tvm.stackEntrySlice": "#/components/schemas/TvmStackEntrySlice",
+                  "tvm.stackEntryCell": "#/components/schemas/TvmStackEntryCell",
+                  "tvm.stackEntryNumber": "#/components/schemas/TvmStackEntryNumber",
+                  "tvm.stackEntryTuple": "#/components/schemas/TvmStackEntryTuple",
+                  "tvm.stackEntryList": "#/components/schemas/TvmStackEntryList",
+                  "tvm.stackEntryUnsupported": "#/components/schemas/TvmStackEntryUnsupported"
+                }
+              }
+            },
+            "description": "Input arguments as a TVM stack. Each entry is a typed object with `@type` discriminator: `tvm.stackEntryNumber` (decimal string), `tvm.stackEntryCell` (base64 BoC), `tvm.stackEntrySlice` (base64 BoC), `tvm.stackEntryTuple`, or `tvm.stackEntryList`."
+          },
+          "seqno": {
+            "type": "integer",
+            "description": "Masterchain block sequence number. Run the get method against the contract state at this specific block height. If omitted, uses the current state."
+          }
+        }
+      },
+      "RunGetMethodStdResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "gas_used",
+          "stack",
+          "exit_code"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "smc.runResult"
+            ],
+            "default": "smc.runResult",
+            "description": "TonLib type identifier for standardized get method execution results. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "gas_used": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Gas consumed during execution. Useful for cost estimation."
+          },
+          "stack": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TvmStackEntrySlice",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryCell",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryNumber",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryTuple",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryList",
+                  "x-usrv-cpp-indirect": true
+                },
+                {
+                  "$ref": "#/components/schemas/TvmStackEntryUnsupported",
+                  "x-usrv-cpp-indirect": true
+                }
+              ],
+              "discriminator": {
+                "propertyName": "@type",
+                "mapping": {
+                  "tvm.stackEntrySlice": "#/components/schemas/TvmStackEntrySlice",
+                  "tvm.stackEntryCell": "#/components/schemas/TvmStackEntryCell",
+                  "tvm.stackEntryNumber": "#/components/schemas/TvmStackEntryNumber",
+                  "tvm.stackEntryTuple": "#/components/schemas/TvmStackEntryTuple",
+                  "tvm.stackEntryList": "#/components/schemas/TvmStackEntryList",
+                  "tvm.stackEntryUnsupported": "#/components/schemas/TvmStackEntryUnsupported"
+                }
+              }
+            },
+            "description": "Output values as a TVM stack. Each entry is a typed object with `@type` discriminator: `tvm.stackEntryNumber` (decimal string), `tvm.stackEntryCell` (base64 BoC), `tvm.stackEntrySlice` (base64 BoC), `tvm.stackEntryTuple`, or `tvm.stackEntryList`."
+          },
+          "exit_code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "TVM exit code. `0` or `1` means success; other values indicate errors. Refer to the [TVM exit code reference](/tvm/exit-codes#exit-codes) for all values."
+          }
+        },
+        "description": "Result of executing a smart contract get method. Contains the TVM exit code (0 or 1 means success), gas consumed, and the output stack with typed return values."
+      },
+      "LegacyTvmCell": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "data",
+          "refs",
+          "special"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "b64",
+              "len"
+            ],
+            "properties": {
+              "b64": {
+                "$ref": "#/components/schemas/Bytes",
+                "description": "Cell data in base64."
+              },
+              "len": {
+                "type": "integer",
+                "format": "int32",
+                "description": "Data length in bits."
+              }
+            },
+            "description": "Cell binary data."
+          },
+          "refs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LegacyTvmCell"
+            },
+            "description": "Array of child cell references, forming a directed acyclic graph (DAG). Each child is a TVM cell object with its own data (base64), refs, and special flag."
+          },
+          "special": {
+            "type": "boolean",
+            "description": "Returns `true` if this is a special (exotic) cell type such as a Merkle proof or library reference; otherwise `false`."
+          }
+        }
+      },
+      "LegacyStackEntryCell": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "bytes"
+        ],
+        "properties": {
+          "bytes": {
+            "$ref": "#/components/schemas/Bytes",
+            "description": "Raw cell bytes in base64."
+          },
+          "object": {
+            "$ref": "#/components/schemas/LegacyTvmCell",
+            "description": "Parsed cell object with data, refs, and type info."
+          }
+        }
+      },
+      "LegacyStackEntry": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer",
+              "format": "int64"
+            },
+            {
+              "$ref": "#/components/schemas/LegacyStackEntryCell"
+            },
+            {
+              "$ref": "#/components/schemas/TvmTuple",
+              "x-usrv-cpp-indirect": true
+            },
+            {
+              "$ref": "#/components/schemas/TvmList",
+              "x-usrv-cpp-indirect": true
+            }
+          ]
+        },
+        "minItems": 2,
+        "maxItems": 2
+      },
+      "RunGetMethodRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "address",
+          "method",
+          "stack"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/TonAddr"
+          },
+          "method": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ],
+            "description": "The get method name (e.g., \"`seqno`\", \"get_wallet_data\") or its numeric ID."
+          },
+          "stack": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LegacyStackEntry"
+            },
+            "description": "Input arguments as a TVM stack. Each entry is a two-element array: `[type, value]` where type is `\"num\"` (decimal string), `\"cell\"` (base64 BoC), or `\"slice\"` (base64 BoC)."
+          },
+          "seqno": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Masterchain block sequence number. Run the get method against the contract state at this specific block height. If omitted, uses the current state."
+          }
+        },
+        "description": "Request to execute a smart contract get method. Specify address, method name/ID, and input stack."
+      },
+      "RunGetMethodResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "@type",
+          "gas_used",
+          "stack",
+          "exit_code",
+          "block_id",
+          "last_transaction_id"
+        ],
+        "properties": {
+          "@type": {
+            "type": "string",
+            "enum": [
+              "smc.runResult"
+            ],
+            "default": "smc.runResult",
+            "description": "TonLib type identifier for get method execution results. Refer to the [TonLib type reference](/ecosystem/api/toncenter/v2-tonlib-types) for a full list."
+          },
+          "gas_used": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Gas consumed during execution. Useful for cost estimation."
+          },
+          "stack": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LegacyStackEntry"
+            },
+            "description": "Output values as a TVM stack. Each entry is a two-element array: `[type, value]` where type is `\"num\"` (decimal string), `\"cell\"` (base64 BoC), or `\"slice\"` (base64 BoC)."
+          },
+          "exit_code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "TVM exit code. `0` or `1` means success; other values indicate errors. Refer to the [TVM exit code reference](/tvm/exit-codes#exit-codes) for all values."
+          },
+          "block_id": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Block at which the get method was executed."
+          },
+          "last_transaction_id": {
+            "$ref": "#/components/schemas/InternalTransactionId",
+            "description": "Most recent transaction at the time of execution."
+          }
+        },
+        "description": "Result of executing a smart contract get method. Contains the TVM exit code (0 or 1 means success), gas used, and the output stack with return values."
+      },
+      "UnpackedAddress": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Decoded address components extracted from a packed base64 address. Contains the workchain, raw hex account ID, and flags for bounceable and testnet formats.",
+        "properties": {
+          "workchain": {
+            "type": "integer",
+            "description": "Workchain ID extracted from the address: `0` for basechain, `-1` for masterchain."
+          },
+          "bounceable": {
+            "type": "boolean",
+            "description": "Returns `true` if the user-friendly address was encoded in bounceable format (flag byte `0x11`); otherwise `false` (non-bounceable, flag byte `0x51`)."
+          },
+          "testnet": {
+            "type": "boolean",
+            "description": "Returns `true` if the user-friendly address has the testnet-only flag set (flag byte includes `0x80`); otherwise `false`. This is a metadata flag in the address encoding. The underlying account can exist on both testnet and mainnet."
+          },
+          "addr_hex": {
+            "type": "string",
+            "description": "The 256-bit `account_id` in hexadecimal (64 characters). Combined with `workchain`, this forms the raw address."
+          }
+        }
+      },
+      "DetectAddressResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/DetectAddress",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "DetectHashResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/DetectHash",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "PackAddressResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "type": "string",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "UnpackAddressResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/UnpackedAddress",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "AddressInformationResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/AddressInformation",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "ExtendedAddressInformationResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/ExtendedAddressInformation",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "WalletInformationResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/WalletInformation",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "AddressBalanceResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/Int256",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "AddressStateResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/AccountStateEnum",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "TokenDataResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/TokenData",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "MasterchainInfoResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/MasterchainInfo",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "MasterchainBlockSignaturesResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/MasterchainBlockSignatures",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "ShardBlockProofResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/ShardBlockProof",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "ConsensusBlockResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/ConsensusBlock",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "LookupBlockResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/TonBlockIdExt",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "ShardsResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/Shards",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        },
+        "description": "Response containing active shardchain blocks for a masterchain block."
+      },
+      "BlockHeaderResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/BlockHeader",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "OutMsgQueueSizeResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/OutMsgQueueSizes"
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "BlockTransactionsResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/BlockTransactions",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "BlockTransactionsExtResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/BlockTransactionsExt",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "TransactionsResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Transaction"
+            },
+            "description": "Array of transaction objects, ordered newest-first. Each transaction contains the triggering inbound message, all outbound messages, fees in nanotons, timestamps, and the raw BoC (base64)."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "TransactionsV2Response": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/TransactionsStd",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        },
+        "description": "Response containing account transactions in V2 format."
+      },
+      "LocateTxResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/Transaction",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "LocateResultTxResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/Transaction",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "LocateSourceTxResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/Transaction",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "ConfigParamResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/ConfigInfo",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "ConfigAllResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/ConfigInfo",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "LibrariesResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/LibraryResult",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "SendBocResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/ResultOk",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "SendBocReturnHashResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/ExtMessageInfo",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "EstimateFeeResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/QueryFees",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "RunGetMethodResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/RunGetMethodResult",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      },
+      "RunGetMethodStdResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "default": true,
+            "description": "Returns `true` if the request succeeded; otherwise `false`. See the `error` field for details."
+          },
+          "result": {
+            "$ref": "#/components/schemas/RunGetMethodStdResult",
+            "description": "Response data. Present only when `ok` is `true`."
+          },
+          "@extra": {
+            "type": "string",
+            "description": "Optional request ID that can be passed in the request and received back in the response. Useful for matching async responses."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `v2.json` next to the existing `v2.yaml`. The YAML is not deleted yet, but `v2.json` should be the source of truth from now on. Future updates should go in the JSON file, following the same conventions.

### Changes

Same 34 endpoints, same API, but the spec just actually documents it now.

**Descriptions**: Every endpoint, parameter, and response has a real description.

**Typed responses**: The YAML used `TonlibResponse` for every single 200 response (65 references). Now each endpoint has its own response schema.

**Error responses**: Instead of one generic `default` error, there are now 21 specific error responses (401, 403, 404, 409, 422 variants per category, 429, 500 variants, 504, 542) with descriptions of what triggers each.

**Removed duplicate POSTs**: The YAML duplicated every GET as a POST under the `rpc` tag. Removed all of those. POST is now only on the 6 endpoints that actually need it: `jsonRPC`, `sendBoc`, `sendBocReturnHash`, `estimateFee`, `runGetMethod`, `runGetMethodStd`.

**Servers block**: Added mainnet (`toncenter.com`) and testnet (`testnet.toncenter.com`) so Swagger UI / Postman work out of the box.

### Conventions for future edits

- Descriptions should explain what the endpoint does and returns, not just repeat the name
- Each endpoint gets its own response schema, don't fall back to `TonlibResponse`
- Error responses should be specific, use the `422_*` pattern
- POST only for endpoints that mutate state or need a request body
- Add examples for non-obvious formats (addresses, hashes, BOCs)
